### PR TITLE
Add project/worktree management and tmux session templates

### DIFF
--- a/examples/test-config.json
+++ b/examples/test-config.json
@@ -35,7 +35,21 @@
     "projects": [
         {
             "repository": "git@github.com:PiquelChips/piquel-cli.git",
-            "default_session": "rust"
+            "default_session": {
+                "windows": [
+                    {
+                        "commands": [
+                            "vim ."
+                        ]
+                    },
+                    {
+                        "commands": [
+                            "git pull",
+                            "cargo clippy"
+                        ]
+                    }
+                ]
+            }
         },
         {
             "repository": "git@github.com:DirkEngine/DirkEngine.git",

--- a/examples/test-config.json
+++ b/examples/test-config.json
@@ -1,0 +1,46 @@
+{
+    "projects_dir": "~/Projects",
+    "default_session": "default",
+    "sessions": {
+        "default": {
+            "windows": [
+                {
+                    "commands": [
+                        "vim ."
+                    ]
+                },
+                {
+                    "commands": [
+                        "git pull"
+                    ]
+                }
+            ]
+        },
+        "rust": {
+            "windows": [
+                {
+                    "commands": [
+                        "vim ."
+                    ]
+                },
+                {
+                    "commands": [
+                        "git pull",
+                        "cargo clippy"
+                    ]
+                }
+            ]
+        }
+    },
+    "projects": [
+        {
+            "repository": "git@github.com:PiquelChips/piquel-cli.git",
+            "default_session": "rust"
+        },
+        {
+            "repository": "git@github.com:DirkEngine/DirkEngine.git",
+            "name": "dirkengine",
+            "default_session": "rust"
+        }
+    ]
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,35 +47,61 @@ in
 
                     sessionConfigType = types.submodule {
                         options = {
-                            root = mkOption {
-                                type = types.str;
-                                description = "Root directory for the session.";
-                            };
                             windows = mkOption {
                                 type = types.listOf windowConfigType;
                                 default = [];
-                                description = "Windows in this session.";
+                                description = "Windows in this session template.";
+                            };
+                        };
+                    };
+
+                    projectConfigType = types.submodule {
+                        options = {
+                            repository = mkOption {
+                                type = types.str;
+                                description = "Git repository URL for the project.";
+                            };
+                            name = mkOption {
+                                type = types.nullOr types.str;
+                                default = null;
+                                description = "Optional configured project name.";
+                            };
+                            path = mkOption {
+                                type = types.nullOr types.str;
+                                default = null;
+                                description = "Optional local project path.";
+                            };
+                            default_session = mkOption {
+                                type = types.nullOr types.str;
+                                default = null;
+                                description = "Optional default session template for this project.";
                             };
                         };
                     };
                 in
                 {
-                    sessions = mkOption {
-                        type = types.attrsOf sessionConfigType;
-                        default  = {};
-                        description = "Named sessions, each with a root path and windows.";
-                    };
-
-                    validate_session_root = mkOption {
-                        type = types.bool;
-                        default = false;
-                        description = "Whetther to validate that the session root is an actual path";
+                    projects_dir = mkOption {
+                        type = types.str;
+                        default = "~/Projects";
+                        description = "Default directory for local projects.";
                     };
 
                     default_session = mkOption {
-                        type = types.listOf windowConfigType;
+                        type = types.str;
+                        default = "default";
+                        description = "Global default session template name.";
+                    };
+
+                    sessions = mkOption {
+                        type = types.attrsOf sessionConfigType;
+                        default  = {};
+                        description = "Named reusable session templates.";
+                    };
+
+                    projects = mkOption {
+                        type = types.listOf projectConfigType;
                         default = [];
-                        description = "Default session to create with any root";
+                        description = "Configured projects.";
                     };
                 };
             };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,114 +1,124 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
-    cfg = config.programs.piquelcli;
-    settingsFormat = pkgs.formats.json { };
-    configFile = settingsFormat.generate "piquel-cli.json" cfg.settings;
+  cfg = config.programs.piquelcli;
+  settingsFormat = pkgs.formats.json { };
+  configFile = settingsFormat.generate "piquel-cli.json" cfg.settings;
 
-    wrappedPiquel =
-        pkgs.runCommand "piquelcli-wrapped"
-            {
-                nativeBuildInputs = [ pkgs.makeWrapper ];
-            }
-            ''
-                makeWrapper ${pkgs.callPackage ./pkg.nix { }}/bin/piquelcli $out/bin/piquel \
-                    --add-flags "--config ${configFile}"
-            '';
+  wrappedPiquel =
+    pkgs.runCommand "piquelcli-wrapped"
+      {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+      }
+      ''
+        makeWrapper ${pkgs.callPackage ./pkg.nix { }}/bin/piquelcli $out/bin/piquel \
+            --add-flags "--config ${configFile}"
+      '';
 
-    piquelcli = wrappedPiquel;
+  piquelcli = wrappedPiquel;
 in
 {
-    options.programs.piquelcli = {
-        enable = lib.mkEnableOption "piquelcli";
+  options.programs.piquelcli = {
+    enable = lib.mkEnableOption "piquelcli";
 
-        package = lib.mkOption {
-            type = lib.types.package;
-            default = piquelcli;
-            defaultText = lib.literalExpression "pkgs.piquel-cli";
-            example = lib.literalExpression "pkgs.piquel-cli";
-        };
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = piquelcli;
+      defaultText = lib.literalExpression "pkgs.piquel-cli";
+      example = lib.literalExpression "pkgs.piquel-cli";
+    };
 
-        settings = lib.mkOption {
-            description = "The configuration being passed to the CLI";
-            type = lib.types.submodule {
-                freeformType = settingsFormat.type;
-                options =
-                let
-                    inherit (lib) mkOption types;
+    settings = lib.mkOption {
+      description = "The configuration being passed to the CLI";
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options =
+          let
+            inherit (lib) mkOption types;
 
-                    windowConfigType = types.submodule {
-                        options = {
-                            commands = mkOption {
-                                type = types.listOf types.str;
-                                default = [];
-                                description = "List of commands to run in the window";
-                            };
-                        };
-                    };
-
-                    sessionConfigType = types.submodule {
-                        options = {
-                            windows = mkOption {
-                                type = types.listOf windowConfigType;
-                                default = [];
-                                description = "Windows in this session template.";
-                            };
-                        };
-                    };
-
-                    projectConfigType = types.submodule {
-                        options = {
-                            repository = mkOption {
-                                type = types.str;
-                                description = "Git repository URL for the project.";
-                            };
-                            name = mkOption {
-                                type = types.nullOr types.str;
-                                default = null;
-                                description = "Optional configured project name.";
-                            };
-                            path = mkOption {
-                                type = types.nullOr types.str;
-                                default = null;
-                                description = "Optional local project path.";
-                            };
-                            default_session = mkOption {
-                                type = types.nullOr types.str;
-                                default = null;
-                                description = "Optional default session template for this project.";
-                            };
-                        };
-                    };
-                in
-                {
-                    projects_dir = mkOption {
-                        type = types.str;
-                        default = "~/Projects";
-                        description = "Default directory for local projects.";
-                    };
-
-                    default_session = mkOption {
-                        type = types.str;
-                        default = "default";
-                        description = "Global default session template name.";
-                    };
-
-                    sessions = mkOption {
-                        type = types.attrsOf sessionConfigType;
-                        default  = {};
-                        description = "Named reusable session templates.";
-                    };
-
-                    projects = mkOption {
-                        type = types.listOf projectConfigType;
-                        default = [];
-                        description = "Configured projects.";
-                    };
+            windowConfigType = types.submodule {
+              options = {
+                commands = mkOption {
+                  type = types.listOf types.str;
+                  default = [ ];
+                  description = "List of commands to run in the window";
                 };
+              };
             };
-        };
-    };
 
-    config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
+            sessionConfigType = types.submodule {
+              options = {
+                windows = mkOption {
+                  type = types.listOf windowConfigType;
+                  default = [ ];
+                  description = "Windows in this session template.";
+                };
+              };
+            };
+
+            projectConfigType = types.submodule {
+              options = {
+                repository = mkOption {
+                  type = types.str;
+                  description = "Git repository URL for the project.";
+                };
+                name = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = "Optional configured project name.";
+                };
+                path = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = "Optional local project path.";
+                };
+                default_session = mkOption {
+                  type = types.nullOr (
+                    types.oneOf [
+                      types.str
+                      sessionConfigType
+                    ]
+                  );
+                  default = null;
+                  description = "Optional default session template name or inline session config for this project.";
+                };
+              };
+            };
+          in
+          {
+            projects_dir = mkOption {
+              type = types.str;
+              default = "~/Projects";
+              description = "Default directory for local projects.";
+            };
+
+            default_session = mkOption {
+              type = types.str;
+              default = "default";
+              description = "Global default session template name.";
+            };
+
+            sessions = mkOption {
+              type = types.attrsOf sessionConfigType;
+              default = { };
+              description = "Named reusable session templates.";
+            };
+
+            projects = mkOption {
+              type = types.listOf projectConfigType;
+              default = [ ];
+              description = "Configured projects.";
+            };
+          };
+      };
     };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+  };
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,9 @@
 use clap::{Parser, Subcommand};
 use std::{error::Error, path::PathBuf};
 
-use crate::config;
+use crate::{config, tmux};
 
+mod projects;
 mod sessions;
 
 /// CLI for personal system management
@@ -20,18 +21,36 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// List all available sessions
-    List {
-        #[arg(short = 'c')]
-        list_config: bool,
-        #[arg(short = 't')]
-        list_tmux: bool,
+    /// List running tmux sessions
+    List,
+    /// Manage configured projects
+    Project {
+        #[command(subcommand)]
+        command: ProjectCommands,
     },
-    /// Load sessions
-    Load { session: String },
-    /// Creates a session with default config
+    /// Open an arbitrary directory with a session template
     #[command(alias = "s")]
-    Session { path: Option<PathBuf> },
+    Session {
+        path: Option<PathBuf>,
+        #[arg(short = 's', long = "session")]
+        session: Option<String>,
+        #[arg(short = 'n', long = "name")]
+        name: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ProjectCommands {
+    /// List configured projects
+    List,
+    /// Load a configured project
+    Load {
+        project: String,
+        #[arg(short = 's', long = "session")]
+        session: Option<String>,
+        #[arg(short = 't', long = "worktree")]
+        worktree: Option<String>,
+    },
 }
 
 pub fn run() -> Result<(), Box<dyn Error>> {
@@ -47,11 +66,19 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     config::load_config(config_path)?;
 
     match &cli.command {
-        Commands::List {
-            list_config,
-            list_tmux,
-        } => sessions::list_sessions(*list_config, *list_tmux),
-        Commands::Load { session } => sessions::load_session(session),
-        Commands::Session { path } => sessions::session(path.clone()),
+        Commands::List => tmux::list_sessions(false, true).map_err(Into::into),
+        Commands::Project { command } => match command {
+            ProjectCommands::List => projects::list_projects(),
+            ProjectCommands::Load {
+                project,
+                session,
+                worktree,
+            } => projects::load_project(project, session.as_deref(), worktree.as_deref()),
+        },
+        Commands::Session {
+            path,
+            session,
+            name,
+        } => sessions::session(path.clone(), session.as_deref(), name.as_deref()),
     }
 }

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -32,10 +32,12 @@ pub fn load_project(
         .project(project_name)
         .ok_or_else(|| format!("Project \"{project_name}\" is not configured"))?;
 
-    let template_name = session_override.unwrap_or(&project.default_session);
     let template = config
-        .session_template(template_name)
-        .ok_or_else(|| format!("Session template \"{template_name}\" is not configured"))?;
+        .project_session_template(&project, session_override)
+        .ok_or_else(|| {
+            let template_name = session_override.unwrap_or("<project default>");
+            format!("Session template \"{template_name}\" is not configured")
+        })?;
 
     if !project.path.exists() {
         return Err(format!(

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -1,0 +1,66 @@
+use std::error::Error;
+
+use crate::{config, git, tmux};
+
+pub fn list_projects() -> Result<(), Box<dyn Error>> {
+    let config = config::config();
+    let mut projects = config
+        .projects
+        .iter()
+        .filter_map(|project| project.resolved_name().ok())
+        .collect::<Vec<_>>();
+
+    projects.sort();
+    projects.dedup();
+
+    for project in projects {
+        println!("{project}");
+    }
+
+    Ok(())
+}
+
+pub fn load_project(
+    project_name: &str,
+    session_override: Option<&str>,
+    worktree: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    tmux::err_in_tmux()?;
+
+    let config = config::config();
+    let project = config
+        .project(project_name)
+        .ok_or_else(|| format!("Project \"{project_name}\" is not configured"))?;
+
+    let template_name = session_override.unwrap_or(&project.default_session);
+    let template = config
+        .session_template(template_name)
+        .ok_or_else(|| format!("Session template \"{template_name}\" is not configured"))?;
+
+    if !project.path.exists() {
+        return Err(format!(
+            "Project \"{}\" path {:?} does not exist; configured repository is {}",
+            project.name, project.path, project.repository
+        )
+        .into());
+    }
+
+    if !project.path.is_dir() {
+        return Err(format!(
+            "Project \"{}\" path {:?} is not a directory; configured repository is {}",
+            project.name, project.path, project.repository
+        )
+        .into());
+    }
+
+    let (root, tmux_name) = match worktree {
+        Some(branch) => {
+            let worktree = git::find_worktree(&project.path, branch)?;
+            (worktree.path, format!("{}--{branch}", project.name))
+        }
+        None => (project.path.clone(), project.name.clone()),
+    };
+
+    tmux::open_session(&tmux_name, &root, template)?;
+    Ok(())
+}

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -1,56 +1,54 @@
-use std::{error::Error, path::PathBuf};
-
-use crate::{
-    SessionConfig, config,
-    tmux::{self, TmuxError},
+use std::{
+    error::Error,
+    path::{Path, PathBuf},
 };
 
-pub fn list_sessions(list_config: bool, list_tmux: bool) -> Result<(), Box<dyn Error>> {
-    if !list_tmux && !list_config {
-        tmux::list_sessions(true, true)?;
-    } else {
-        tmux::list_sessions(list_config, list_tmux)?;
-    }
-    Ok(())
-}
+use crate::{config, tmux};
 
-pub fn load_session(session: &String) -> Result<(), Box<dyn Error>> {
-    tmux::err_in_tmux()?;
-
-    let sessions = tmux::list_tmux_sessions()?;
-
-    if sessions.contains(session) {
-        match tmux::attach(session) {
-            Ok(_) => return Ok(()),
-            Err(TmuxError::Command(ref msg)) if !msg.starts_with("can't find session:") => {
-                return Err(msg.clone().into());
-            }
-            Err(_) => {}
-        }
-    }
-
-    let config = config::config();
-    let session_config = config.sessions.get(session).ok_or("Invalid session")?;
-    Ok(tmux::new_session(session, &session_config)?)
-}
-
-pub fn session(path: Option<PathBuf>) -> Result<(), Box<dyn Error>> {
+pub fn session(
+    path: Option<PathBuf>,
+    session_override: Option<&str>,
+    name_override: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
     tmux::err_in_tmux()?;
 
     let config = config::config();
+    let template_name = session_override.unwrap_or(&config.default_session);
+    let template = config
+        .session_template(template_name)
+        .ok_or_else(|| format!("Session template \"{template_name}\" is not configured"))?;
 
-    let path: PathBuf = match path {
-        Some(path) => path.to_owned(),
+    let root = match path {
+        Some(path) => expand_home(&path),
         None => std::env::current_dir()?,
     };
 
-    let session = SessionConfig {
-        windows: config.default_session.clone(),
-        root: path,
+    if !root.exists() {
+        return Err(format!("Session path {root:?} does not exist").into());
+    }
+
+    if !root.is_dir() {
+        return Err(format!("Session path {root:?} is not a directory").into());
+    }
+
+    let tmux_name = match name_override {
+        Some(name) => name.to_owned(),
+        None => root
+            .file_name()
+            .ok_or_else(|| format!("Could not derive session name from path {root:?}"))?
+            .to_string_lossy()
+            .into_owned(),
     };
 
-    let root = session.root.to_string_lossy();
-    let name_split: Vec<&str> = root.split("/").collect();
-    let session_name = name_split[name_split.len() - 1];
-    Ok(tmux::new_session(session_name, &session)?)
+    tmux::open_session(&tmux_name, &root, template)?;
+    Ok(())
+}
+
+fn expand_home(path: &Path) -> PathBuf {
+    if let Ok(stripped) = path.strip_prefix("~")
+        && let Some(home) = std::env::home_dir()
+    {
+        return home.join(stripped);
+    }
+    path.to_path_buf()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,12 +44,7 @@ pub fn load_config(config_path: &Path) -> Result<(), ConfigError> {
         .map_err(|_| ConfigError::FileNotFound(config_path.to_owned()))?;
 
     let mut parsed: Config = serde_json::from_str(&config_file).map_err(ConfigError::ParseError)?;
-
-    for (name, session) in parsed.sessions.iter_mut() {
-        // TODO: replace name in the HashMap
-        let session_name = name.replace('.', "_");
-        session.validate(&session_name, parsed.validate_session_root)?;
-    }
+    parsed.validate_and_normalize()?;
 
     // `set` fails only if another thread raced us — treat that as already loaded.
     CONFIG.set(parsed).map_err(|_| ConfigError::AlreadyLoaded)

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,228 @@
+use std::{
+    io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Worktree {
+    pub path: PathBuf,
+    pub branch: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum GitError {
+    Io(io::Error),
+    Command(String),
+    MissingProjectPath(PathBuf),
+    MissingWorktree {
+        branch: String,
+        project_path: PathBuf,
+    },
+    Parse(String),
+}
+
+impl std::fmt::Display for GitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GitError::Io(e) => write!(f, "IO error: {e}"),
+            GitError::Command(msg) => write!(f, "{msg}"),
+            GitError::MissingProjectPath(path) => {
+                write!(f, "Project path {path:?} does not exist")
+            }
+            GitError::MissingWorktree {
+                branch,
+                project_path,
+            } => write!(
+                f,
+                "No local git worktree for branch \"{branch}\" exists under {project_path:?}"
+            ),
+            GitError::Parse(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for GitError {}
+
+impl From<io::Error> for GitError {
+    fn from(e: io::Error) -> Self {
+        GitError::Io(e)
+    }
+}
+
+pub fn list_worktrees(project_path: &Path) -> Result<Vec<Worktree>, GitError> {
+    if !project_path.exists() {
+        return Err(GitError::MissingProjectPath(project_path.to_owned()));
+    }
+
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .map_err(GitError::Io)?;
+
+    let combined = {
+        let mut s = String::from_utf8_lossy(&output.stdout).into_owned();
+        s.push_str(&String::from_utf8_lossy(&output.stderr));
+        s
+    };
+
+    if !output.status.success() {
+        return Err(GitError::Command(combined));
+    }
+
+    parse_worktrees(&combined)
+}
+
+pub fn find_worktree(project_path: &Path, branch: &str) -> Result<Worktree, GitError> {
+    find_worktree_in(list_worktrees(project_path)?, project_path, branch)
+}
+
+fn find_worktree_in(
+    worktrees: Vec<Worktree>,
+    project_path: &Path,
+    branch: &str,
+) -> Result<Worktree, GitError> {
+    worktrees
+        .into_iter()
+        .find(|worktree| worktree.branch.as_deref() == Some(branch))
+        .ok_or_else(|| GitError::MissingWorktree {
+            branch: branch.to_owned(),
+            project_path: project_path.to_owned(),
+        })
+}
+
+fn parse_worktrees(input: &str) -> Result<Vec<Worktree>, GitError> {
+    let mut worktrees = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_branch: Option<String> = None;
+
+    for line in input.lines() {
+        if line.is_empty() {
+            push_worktree(&mut worktrees, current_path.take(), current_branch.take())?;
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("worktree ") {
+            push_worktree(&mut worktrees, current_path.take(), current_branch.take())?;
+            current_path = Some(PathBuf::from(path));
+            continue;
+        }
+
+        if let Some(branch) = line.strip_prefix("branch refs/heads/") {
+            current_branch = Some(branch.to_owned());
+        }
+    }
+
+    push_worktree(&mut worktrees, current_path.take(), current_branch.take())?;
+    Ok(worktrees)
+}
+
+fn push_worktree(
+    worktrees: &mut Vec<Worktree>,
+    path: Option<PathBuf>,
+    branch: Option<String>,
+) -> Result<(), GitError> {
+    if let Some(path) = path {
+        worktrees.push(Worktree { path, branch });
+    } else if branch.is_some() {
+        return Err(GitError::Parse(
+            "Found git worktree branch before worktree path".to_owned(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_multiple_worktrees_and_branch_names_with_slashes() {
+        let output = "\
+worktree /home/me/Projects/repo
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree /home/me/Projects/repo-feature
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/feature/foo
+
+";
+
+        let worktrees = parse_worktrees(output).unwrap();
+
+        assert_eq!(
+            worktrees,
+            vec![
+                Worktree {
+                    path: PathBuf::from("/home/me/Projects/repo"),
+                    branch: Some("main".to_owned())
+                },
+                Worktree {
+                    path: PathBuf::from("/home/me/Projects/repo-feature"),
+                    branch: Some("feature/foo".to_owned())
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn detached_worktrees_have_no_branch() {
+        let output = "\
+worktree /home/me/Projects/repo-detached
+HEAD 3333333333333333333333333333333333333333
+detached
+
+";
+
+        let worktrees = parse_worktrees(output).unwrap();
+
+        assert_eq!(worktrees[0].branch, None);
+    }
+
+    #[test]
+    fn exact_branch_lookup_ignores_detached_head() {
+        let output = "\
+worktree /home/me/Projects/repo
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree /home/me/Projects/repo-detached
+HEAD 3333333333333333333333333333333333333333
+detached
+
+";
+
+        let worktrees = parse_worktrees(output).unwrap();
+        let found = find_worktree_in(worktrees, Path::new("/home/me/Projects/repo"), "main")
+            .expect("main worktree should exist");
+
+        assert_eq!(found.path, PathBuf::from("/home/me/Projects/repo"));
+    }
+
+    #[test]
+    fn missing_branch_returns_an_error() {
+        let output = "\
+worktree /home/me/Projects/repo
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree /home/me/Projects/repo-detached
+HEAD 3333333333333333333333333333333333333333
+detached
+
+";
+
+        let err = find_worktree_in(
+            parse_worktrees(output).unwrap(),
+            Path::new("/home/me/Projects/repo"),
+            "feature/foo",
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("feature/foo"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,14 @@ use std::{
 
 use crate::config::ConfigError;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct WindowConfig {
     #[serde(default)]
     commands: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct SessionConfig {
     windows: Vec<WindowConfig>,
@@ -48,7 +48,7 @@ pub struct ProjectConfig {
     repository: String,
     name: Option<String>,
     path: Option<PathBuf>,
-    default_session: Option<String>,
+    default_session: Option<ProjectSessionConfig>,
 }
 
 impl ProjectConfig {
@@ -69,11 +69,18 @@ impl ProjectConfig {
         }
     }
 
-    pub fn resolved_default_session<'a>(&'a self, config: &'a Config) -> &'a str {
+    pub fn resolved_default_session(&self, config: &Config) -> ProjectSessionConfig {
         self.default_session
-            .as_deref()
-            .unwrap_or(&config.default_session)
+            .clone()
+            .unwrap_or_else(|| ProjectSessionConfig::Template(config.default_session.clone()))
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ProjectSessionConfig {
+    Template(String),
+    Inline(SessionConfig),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -119,16 +126,26 @@ impl Config {
             project.name = Some(name);
             project.path = Some(path);
 
-            let template_name = project
+            match project
                 .default_session
-                .as_deref()
-                .unwrap_or(&global_default_session);
-
-            if !self.sessions.contains_key(template_name) {
-                return Err(ConfigError::Validation(format!(
-                    "Project \"{}\" references unknown session template \"{template_name}\"",
-                    project.name.as_deref().unwrap_or("<unknown>")
-                )));
+                .as_ref()
+                .unwrap_or(&ProjectSessionConfig::Template(
+                    global_default_session.clone(),
+                )) {
+                ProjectSessionConfig::Template(template_name) => {
+                    if !self.sessions.contains_key(template_name) {
+                        return Err(ConfigError::Validation(format!(
+                            "Project \"{}\" references unknown session template \"{template_name}\"",
+                            project.name.as_deref().unwrap_or("<unknown>")
+                        )));
+                    }
+                }
+                ProjectSessionConfig::Inline(session) => {
+                    session.validate(&format!(
+                        "Project \"{}\" inline default_session",
+                        project.name.as_deref().unwrap_or("<unknown>")
+                    ))?;
+                }
             }
         }
 
@@ -150,9 +167,24 @@ impl Config {
                 repository: project.repository.clone(),
                 name: resolved_name,
                 path: project.resolved_path(&self.projects_dir).ok()?,
-                default_session: project.resolved_default_session(self).to_owned(),
+                default_session: project.resolved_default_session(self),
             })
         })
+    }
+
+    pub fn project_session_template<'a>(
+        &'a self,
+        project: &'a ResolvedProject,
+        session_override: Option<&str>,
+    ) -> Option<&'a SessionConfig> {
+        if let Some(template_name) = session_override {
+            return self.session_template(template_name);
+        }
+
+        match &project.default_session {
+            ProjectSessionConfig::Template(template_name) => self.session_template(template_name),
+            ProjectSessionConfig::Inline(session) => Some(session),
+        }
     }
 }
 
@@ -161,7 +193,7 @@ pub struct ResolvedProject {
     repository: String,
     name: String,
     path: PathBuf,
-    default_session: String,
+    default_session: ProjectSessionConfig,
 }
 
 /// Replaces '~' with the contents of $HOME
@@ -311,7 +343,45 @@ mod tests {
             repository: "git@github.com:owner/repo.git".to_owned(),
             name: None,
             path: None,
-            default_session: Some("missing".to_owned()),
+            default_session: Some(ProjectSessionConfig::Template("missing".to_owned())),
+        });
+
+        assert!(config.validate_and_normalize().is_err());
+    }
+
+    #[test]
+    fn project_default_session_can_be_inline() {
+        let mut config = config_with_default();
+        config.projects.push(ProjectConfig {
+            repository: "git@github.com:owner/repo.git".to_owned(),
+            name: None,
+            path: None,
+            default_session: Some(ProjectSessionConfig::Inline(SessionConfig {
+                windows: vec![WindowConfig {
+                    commands: vec!["cargo check".to_owned()],
+                }],
+            })),
+        });
+
+        config.validate_and_normalize().unwrap();
+        let project = config.project("repo").unwrap();
+
+        assert!(matches!(
+            project.default_session,
+            ProjectSessionConfig::Inline(_)
+        ));
+    }
+
+    #[test]
+    fn inline_project_default_session_must_have_windows() {
+        let mut config = config_with_default();
+        config.projects.push(ProjectConfig {
+            repository: "git@github.com:owner/repo.git".to_owned(),
+            name: None,
+            path: None,
+            default_session: Some(ProjectSessionConfig::Inline(SessionConfig {
+                windows: vec![],
+            })),
         });
 
         assert!(config.validate_and_normalize().is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,59 +1,41 @@
 pub mod cli;
 pub mod config;
+pub mod git;
 pub mod tmux;
 
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
 use crate::config::ConfigError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WindowConfig {
-    pub commands: Vec<String>,
+    #[serde(default)]
+    commands: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SessionConfig {
-    pub root: PathBuf,
-    pub windows: Vec<WindowConfig>,
+    windows: Vec<WindowConfig>,
 }
 
 impl SessionConfig {
-    fn validate(
-        &mut self,
-        name: &str,
-        validate_session_root: bool,
-    ) -> Result<(), config::ConfigError> {
-        if name.trim().is_empty() || name.contains('.') {
+    fn validate(&self, name: &str) -> Result<(), config::ConfigError> {
+        if name.trim().is_empty() || name.contains(':') {
             return Err(ConfigError::Validation(format!(
-                "\"{name}\" is not a valid session name"
+                "\"{name}\" is not a valid session template name"
             )));
         }
 
-        self.root = expand_home(&self.root);
-
-        if validate_session_root {
-            if !self.root.exists() {
-                return Err(ConfigError::Validation(format!(
-                    "Path {:?} does not exist",
-                    self.root
-                )));
-            }
-            if !self.root.is_dir() {
-                return Err(ConfigError::Validation(format!(
-                    "Path {:?} is not a directory",
-                    self.root
-                )));
-            }
-        }
-
         if self.windows.is_empty() {
-            return Err(ConfigError::Validation(
-                "Session must have at least one window".to_owned(),
-            ));
+            return Err(ConfigError::Validation(format!(
+                "Session template \"{name}\" must have at least one window"
+            )));
         }
 
         Ok(())
@@ -61,18 +43,314 @@ impl SessionConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectConfig {
+    repository: String,
+    name: Option<String>,
+    path: Option<PathBuf>,
+    default_session: Option<String>,
+}
+
+impl ProjectConfig {
+    pub fn resolved_name(&self) -> Result<String, ConfigError> {
+        let name = match &self.name {
+            Some(name) => name.clone(),
+            None => repository_basename(&self.repository)?,
+        };
+
+        validate_project_name(&name)?;
+        Ok(name)
+    }
+
+    pub fn resolved_path(&self, projects_dir: &Path) -> Result<PathBuf, ConfigError> {
+        match &self.path {
+            Some(path) => Ok(expand_home(path)),
+            None => Ok(projects_dir.join(self.resolved_name()?)),
+        }
+    }
+
+    pub fn resolved_default_session<'a>(&'a self, config: &'a Config) -> &'a str {
+        self.default_session
+            .as_deref()
+            .unwrap_or(&config.default_session)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
-    pub sessions: HashMap<String, SessionConfig>,
-    pub validate_session_root: bool,
-    pub default_session: Vec<WindowConfig>, // a session without a root
+    #[serde(default = "default_projects_dir")]
+    projects_dir: PathBuf,
+    #[serde(default = "default_default_session")]
+    default_session: String,
+    #[serde(default)]
+    sessions: HashMap<String, SessionConfig>,
+    #[serde(default)]
+    projects: Vec<ProjectConfig>,
+}
+
+impl Config {
+    pub fn validate_and_normalize(&mut self) -> Result<(), ConfigError> {
+        self.projects_dir = expand_home(&self.projects_dir);
+
+        for (name, session) in &self.sessions {
+            session.validate(name)?;
+        }
+
+        if !self.sessions.contains_key(&self.default_session) {
+            return Err(ConfigError::Validation(format!(
+                "Default session template \"{}\" does not exist",
+                self.default_session
+            )));
+        }
+
+        let mut project_names = HashSet::new();
+        let global_default_session = self.default_session.clone();
+
+        for project in &mut self.projects {
+            let name = project.resolved_name()?;
+            if !project_names.insert(name.clone()) {
+                return Err(ConfigError::Validation(format!(
+                    "Duplicate project name \"{name}\""
+                )));
+            }
+
+            let path = project.resolved_path(&self.projects_dir)?;
+            project.name = Some(name);
+            project.path = Some(path);
+
+            let template_name = project
+                .default_session
+                .as_deref()
+                .unwrap_or(&global_default_session);
+
+            if !self.sessions.contains_key(template_name) {
+                return Err(ConfigError::Validation(format!(
+                    "Project \"{}\" references unknown session template \"{template_name}\"",
+                    project.name.as_deref().unwrap_or("<unknown>")
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn session_template(&self, name: &str) -> Option<&SessionConfig> {
+        self.sessions.get(name)
+    }
+
+    pub fn project(&self, name: &str) -> Option<ResolvedProject> {
+        self.projects.iter().find_map(|project| {
+            let resolved_name = project.resolved_name().ok()?;
+            if resolved_name != name {
+                return None;
+            }
+
+            Some(ResolvedProject {
+                repository: project.repository.clone(),
+                name: resolved_name,
+                path: project.resolved_path(&self.projects_dir).ok()?,
+                default_session: project.resolved_default_session(self).to_owned(),
+            })
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedProject {
+    repository: String,
+    name: String,
+    path: PathBuf,
+    default_session: String,
 }
 
 /// Replaces '~' with the contents of $HOME
 fn expand_home(path: &Path) -> PathBuf {
-    if let Ok(stripped) = path.strip_prefix("~") {
-        if let Some(home) = std::env::home_dir() {
-            return home.join(stripped);
-        }
+    if let Ok(stripped) = path.strip_prefix("~")
+        && let Some(home) = std::env::home_dir()
+    {
+        return home.join(stripped);
     }
     path.to_path_buf()
+}
+
+fn default_projects_dir() -> PathBuf {
+    PathBuf::from("~/Projects")
+}
+
+fn default_default_session() -> String {
+    "default".to_owned()
+}
+
+fn repository_basename(repository: &str) -> Result<String, ConfigError> {
+    let trimmed = repository.trim().trim_end_matches('/');
+    let basename = trimmed.rsplit(['/', ':']).next().unwrap_or(trimmed);
+    let basename = basename.strip_suffix(".git").unwrap_or(basename).to_owned();
+
+    validate_project_name(&basename)?;
+    Ok(basename)
+}
+
+fn validate_project_name(name: &str) -> Result<(), ConfigError> {
+    if name.trim().is_empty() || name.contains(':') {
+        return Err(ConfigError::Validation(format!(
+            "\"{name}\" is not a valid project name"
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window() -> WindowConfig {
+        WindowConfig { commands: vec![] }
+    }
+
+    fn session() -> SessionConfig {
+        SessionConfig {
+            windows: vec![window()],
+        }
+    }
+
+    fn config_with_default() -> Config {
+        Config {
+            projects_dir: PathBuf::from("~/Projects"),
+            default_session: "default".to_owned(),
+            sessions: HashMap::from([("default".to_owned(), session())]),
+            projects: vec![],
+        }
+    }
+
+    #[test]
+    fn expands_projects_dir_and_project_path() {
+        let home = std::env::home_dir().expect("HOME should be set for tests");
+        let mut config = config_with_default();
+        config.projects.push(ProjectConfig {
+            repository: "git@github.com:owner/repo.git".to_owned(),
+            name: None,
+            path: Some(PathBuf::from("~/src/repo")),
+            default_session: None,
+        });
+
+        config.validate_and_normalize().unwrap();
+
+        assert_eq!(config.projects_dir, home.join("Projects"));
+        assert_eq!(config.projects[0].path, Some(home.join("src/repo")));
+    }
+
+    #[test]
+    fn derives_project_name_from_repository_basename() {
+        for (repository, expected) in [
+            ("git@github.com:owner/repo.git", "repo"),
+            ("https://github.com/owner/repo.git", "repo"),
+            ("https://github.com/owner/repo", "repo"),
+        ] {
+            let project = ProjectConfig {
+                repository: repository.to_owned(),
+                name: None,
+                path: None,
+                default_session: None,
+            };
+
+            assert_eq!(project.resolved_name().unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn missing_global_default_session_fails_validation() {
+        let mut config = Config {
+            projects_dir: PathBuf::from("~/Projects"),
+            default_session: "missing".to_owned(),
+            sessions: HashMap::from([("default".to_owned(), session())]),
+            projects: vec![],
+        };
+
+        assert!(config.validate_and_normalize().is_err());
+    }
+
+    #[test]
+    fn empty_session_template_windows_fail_validation() {
+        let mut config = Config {
+            projects_dir: PathBuf::from("~/Projects"),
+            default_session: "default".to_owned(),
+            sessions: HashMap::from([("default".to_owned(), SessionConfig { windows: vec![] })]),
+            projects: vec![],
+        };
+
+        assert!(config.validate_and_normalize().is_err());
+    }
+
+    #[test]
+    fn duplicate_resolved_project_names_fail_validation() {
+        let mut config = config_with_default();
+        config.projects = vec![
+            ProjectConfig {
+                repository: "git@github.com:owner/repo.git".to_owned(),
+                name: None,
+                path: None,
+                default_session: None,
+            },
+            ProjectConfig {
+                repository: "https://github.com/other/repo.git".to_owned(),
+                name: None,
+                path: None,
+                default_session: None,
+            },
+        ];
+
+        assert!(config.validate_and_normalize().is_err());
+    }
+
+    #[test]
+    fn project_default_session_must_exist() {
+        let mut config = config_with_default();
+        config.projects.push(ProjectConfig {
+            repository: "git@github.com:owner/repo.git".to_owned(),
+            name: None,
+            path: None,
+            default_session: Some("missing".to_owned()),
+        });
+
+        assert!(config.validate_and_normalize().is_err());
+    }
+
+    #[test]
+    fn project_path_defaults_to_projects_dir_and_project_name() {
+        let mut config = config_with_default();
+        config.projects_dir = PathBuf::from("/tmp/projects");
+        config.projects.push(ProjectConfig {
+            repository: "git@github.com:owner/repo.git".to_owned(),
+            name: None,
+            path: None,
+            default_session: None,
+        });
+
+        config.validate_and_normalize().unwrap();
+
+        assert_eq!(
+            config.projects[0].path,
+            Some(PathBuf::from("/tmp/projects/repo"))
+        );
+    }
+
+    #[test]
+    fn old_rooted_session_schema_is_rejected() {
+        let err = serde_json::from_str::<Config>(
+            r#"{
+                "default_session": "default",
+                "sessions": {
+                    "default": {
+                        "root": "/tmp",
+                        "windows": [{ "commands": [] }]
+                    }
+                }
+            }"#,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unknown field `root`"));
+    }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,6 +1,6 @@
 use crate::{SessionConfig, WindowConfig, config};
 use std::io;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 #[derive(Debug)]
@@ -8,6 +8,7 @@ pub enum TmuxError {
     Io(io::Error),
     Command(String),
     InTmux,
+    InvalidSessionName(String),
 }
 
 impl std::fmt::Display for TmuxError {
@@ -16,6 +17,9 @@ impl std::fmt::Display for TmuxError {
             TmuxError::Io(e) => write!(f, "IO error: {e}"),
             TmuxError::Command(msg) => write!(f, "{msg}"),
             TmuxError::InTmux => write!(f, "Please do not use this command in tmux"),
+            TmuxError::InvalidSessionName(name) => {
+                write!(f, "\"{name}\" is not a valid tmux session name")
+            }
         }
     }
 }
@@ -40,8 +44,10 @@ pub fn list_sessions(list_config: bool, list_tmux: bool) -> Result<(), TmuxError
     }
 
     if list_config {
-        for session_name in config.sessions.keys() {
-            sessions.push(session_name.clone());
+        for project in &config.projects {
+            if let Ok(project_name) = project.resolved_name() {
+                sessions.push(project_name);
+            }
         }
     }
 
@@ -86,42 +92,57 @@ pub fn attach(session: &str) -> Result<String, TmuxError> {
     exec_tmux_return(&["attach", "-t", session])
 }
 
-/// Creates a new tmux session (and its windows), then attaches.
-pub fn new_session(session_name: &str, session: &SessionConfig) -> Result<(), TmuxError> {
-    exec_tmux(&[
-        "new-session",
-        "-Ad",
-        "-c",
-        &session.root.to_string_lossy(),
-        "-s",
-        &session_name,
-    ])
-    .map_err(|_| {
-        TmuxError::Command(format!("Failed to create session with name {session_name}"))
-    })?;
+/// Opens a tmux session for `root` using `template`, creating it when needed.
+pub fn open_session(
+    tmux_name: &str,
+    root: &Path,
+    template: &SessionConfig,
+) -> Result<(), TmuxError> {
+    let tmux_name = validated_session_name(tmux_name)?;
 
-    let index = exec_tmux_return(&["list-windows", "-t", &session_name, "-F", "#{window_index}"])
-        .map_err(|e| {
-        TmuxError::Command(format!("Failed to list tmux windows with error: {e}"))
-    })?;
-
-    let index = index.trim_matches('\n').to_owned();
-
-    for (i, window) in session.windows.iter().enumerate() {
-        new_window(&session.root, window).map_err(|e| {
-            TmuxError::Command(format!("Failed to create window {} with error: {e}", i + 1))
-        })?;
+    let sessions = list_tmux_sessions()?;
+    if sessions.contains(&tmux_name) {
+        attach(&tmux_name)?;
+        return Ok(());
     }
 
-    exec_tmux(&["kill-window", "-t", &format!("{session_name}:{index}")])
+    exec_tmux(&[
+        "new-session",
+        "-d",
+        "-c",
+        &root.to_string_lossy(),
+        "-s",
+        &tmux_name,
+    ])
+    .map_err(|_| TmuxError::Command(format!("Failed to create session with name {tmux_name}")))?;
+
+    let bootstrap_window =
+        exec_tmux_return(&["list-windows", "-t", &tmux_name, "-F", "#{window_id}"]).map_err(
+            |e| TmuxError::Command(format!("Failed to list tmux windows with error: {e}")),
+        )?;
+
+    let bootstrap_window = bootstrap_window.trim_matches('\n').to_owned();
+    let mut first_window = None;
+
+    for (i, window) in template.windows.iter().enumerate() {
+        let window_id = new_window(&tmux_name, root, window).map_err(|e| {
+            TmuxError::Command(format!("Failed to create window {} with error: {e}", i + 1))
+        })?;
+
+        first_window.get_or_insert(window_id);
+    }
+
+    exec_tmux(&["kill-window", "-t", &bootstrap_window])
         .map_err(|_| TmuxError::Command("Failed to kill first window".to_owned()))?;
 
-    exec_tmux(&["select-window", "-t", &format!("{session_name}:{index}")])
-        .map_err(|_| TmuxError::Command("Failed to select first window".to_owned()))?;
+    if let Some(first_window) = first_window {
+        exec_tmux(&["select-window", "-t", &first_window])
+            .map_err(|_| TmuxError::Command("Failed to select first window".to_owned()))?;
+    }
 
-    attach(&session_name).map_err(|_| {
+    attach(&tmux_name).map_err(|_| {
         TmuxError::Command(format!(
-            "Failed to attach to session with error: {session_name}"
+            "Failed to attach to session with error: {tmux_name}"
         ))
     })?;
 
@@ -129,19 +150,34 @@ pub fn new_session(session_name: &str, session: &SessionConfig) -> Result<(), Tm
 }
 
 /// Creates a new tmux window rooted at `start_dir` and sends its commands.
-pub fn new_window(start_dir: &PathBuf, window: &WindowConfig) -> Result<(), TmuxError> {
-    exec_tmux_return(&["new-window", "-c", start_dir.to_str().unwrap()])
-        .map_err(|e| TmuxError::Command(format!("Failed to create window with error: {e}")))?;
+pub fn new_window(
+    session_name: &str,
+    start_dir: &Path,
+    window: &WindowConfig,
+) -> Result<String, TmuxError> {
+    let window_id = exec_tmux_return(&[
+        "new-window",
+        "-P",
+        "-F",
+        "#{window_id}",
+        "-t",
+        session_name,
+        "-c",
+        start_dir.to_str().unwrap(),
+    ])
+    .map_err(|e| TmuxError::Command(format!("Failed to create window with error: {e}")))?;
+
+    let window_id = window_id.trim_matches('\n').to_owned();
 
     for command in &window.commands {
-        exec_tmux_return(&["send-keys", command, "Enter"]).map_err(|e| {
+        exec_tmux_return(&["send-keys", "-t", &window_id, command, "Enter"]).map_err(|e| {
             TmuxError::Command(format!(
                 "Failed to execute command \"{command}\" with error: {e}"
             ))
         })?;
     }
 
-    Ok(())
+    Ok(window_id)
 }
 
 /// Will return an error we are in tmux
@@ -155,6 +191,46 @@ pub fn err_in_tmux() -> Result<(), TmuxError> {
 
 pub fn in_tmux() -> bool {
     std::env::var("TMUX").is_ok()
+}
+
+pub fn sanitize_session_name(input: &str) -> String {
+    let mut sanitized = String::new();
+    let mut last_was_underscore = false;
+
+    for ch in input.trim().chars() {
+        let next = if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            ch
+        } else {
+            '_'
+        };
+
+        if next == '_' {
+            if last_was_underscore {
+                continue;
+            }
+            last_was_underscore = true;
+        } else {
+            last_was_underscore = false;
+        }
+
+        sanitized.push(next);
+    }
+
+    sanitized
+}
+
+pub fn validated_session_name(input: &str) -> Result<String, TmuxError> {
+    let trimmed = input.trim();
+    let sanitized = sanitize_session_name(trimmed);
+    let has_valid_char = trimmed
+        .chars()
+        .any(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-');
+
+    if sanitized.is_empty() || !has_valid_char {
+        return Err(TmuxError::InvalidSessionName(input.to_owned()));
+    }
+
+    Ok(sanitized)
 }
 
 fn exec_tmux(args: &[&str]) -> Result<(), TmuxError> {
@@ -191,5 +267,25 @@ fn exec_tmux_return(args: &[&str]) -> Result<String, TmuxError> {
         Ok(combined)
     } else {
         Err(TmuxError::Command(combined))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_tmux_session_names() {
+        assert_eq!(sanitize_session_name("project:branch"), "project_branch");
+        assert_eq!(sanitize_session_name("feature/foo"), "feature_foo");
+        assert_eq!(sanitize_session_name("feature///foo"), "feature_foo");
+        assert!(!sanitize_session_name("project:branch").contains(':'));
+    }
+
+    #[test]
+    fn invalid_tmux_session_names_fail_validation() {
+        assert!(validated_session_name("").is_err());
+        assert!(validated_session_name("   ").is_err());
+        assert!(validated_session_name("///").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Add a new project workflow with `project list` and `project load`, including optional worktree selection for loading a branch-specific worktree.
- Redesign config around reusable session templates plus configured projects, with validation and normalization for project names, paths, and default session bindings.
- Update tmux session creation to open sessions from templates, sanitize session names, and attach to existing sessions when present.
- Refresh the Nix module and add an example config for the new project/session schema.