### PR TITLE
feat: managed worktree handling to project picking

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ Fields:
 - `sessions.*.windows[].commands`: commands sent to the created tmux window,
   each followed by `Enter`.
 
-Project and session names must not be empty or contain `:`. tmux session names
-derived from worktree branches are sanitized before tmux is invoked.
+Project names must be safe path segments: they must not be empty, `.`, `..`, or
+contain `/`, `\`, or `:`. Session names must not be empty or contain `:`. tmux
+session names derived from worktree branches are sanitized before tmux is
+invoked.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Commands:
 
 ```text
 piquel list
-piquel pick
+piquel pick [project] [--session <template>]
 piquel project list
 piquel project load <project> [--session <template>] [--worktree <branch>]
 piquel session [path] [--session <template>] [--name <tmux-name>]
@@ -49,11 +49,28 @@ piquel session [path] [--session <template>] [--name <tmux-name>]
 
 `piquel list` prints running tmux sessions. `piquel pick` combines running
 tmux sessions and configured projects, lets `fzf` select one, then attaches to
-the session or opens the project.
+the session or opens the project branch workflow. `piquel pick <project>` skips
+the first picker and opens that project's branch workflow directly.
+
+The branch picker lists local git branches only. It does not fetch and does not
+create remote-tracking branches. If the selected branch already has a worktree,
+`piquel` opens it. If not, `piquel` creates a managed worktree at
+`<worktrees_dir>/<project>/<sanitized-branch>`.
+
+Branch-selected tmux sessions use `project--branch` names, with the branch
+sanitized for tmux. This also applies when the selected branch is checked out at
+the configured project path. Branch-aware workflows use the plain `project`
+session name only when the project has no local branches.
+
+`piquel pick --session <template>` uses the template override only when a
+project is opened. Selecting an existing tmux session still attaches to that
+session unchanged.
 
 `piquel project load` opens a configured project. When `--worktree` is set,
-the CLI runs `git worktree list --porcelain` under the project path and opens
-the matching branch worktree.
+the CLI opens the requested local branch worktree, creating a managed worktree
+if the branch does not already have one. Bare `piquel project load <project>`
+keeps the legacy behavior: it opens the configured project path with tmux
+session name `project`.
 
 `piquel session` opens an arbitrary directory with a configured session
 template. If no path is given, it uses the current working directory. If no
@@ -83,6 +100,7 @@ Fuller project config:
 ```json
 {
   "projects_dir": "~/Projects",
+  "worktrees_dir": "~/.piquel/worktrees",
   "default_session": "default",
   "sessions": {
     "default": {
@@ -131,6 +149,8 @@ Fields:
 
 - `projects_dir`: base directory for projects without an explicit `path`.
   Defaults to `~/Projects`.
+- `worktrees_dir`: base directory for managed branch worktrees. Defaults to
+  `~/.piquel/worktrees`.
 - `default_session`: the session template used when a project does not specify
   one. Defaults to `default`.
 - `sessions`: named tmux session templates. Each template must have at least

--- a/examples/test-config.json
+++ b/examples/test-config.json
@@ -1,5 +1,6 @@
 {
     "projects_dir": "~/Projects",
+    "worktrees_dir": "~/.piquel/worktrees",
     "default_session": "default",
     "sessions": {
         "default": {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -103,6 +103,12 @@ in
               description = "Default directory for local projects.";
             };
 
+            worktrees_dir = mkOption {
+              type = types.str;
+              default = "~/.piquel/worktrees";
+              description = "Default directory for managed project worktrees.";
+            };
+
             default_session = mkOption {
               type = types.str;
               default = "default";

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,13 @@ pub enum Commands {
     /// List running tmux sessions
     List,
     /// Interactively pick a running tmux session or configured project
-    Pick,
+    Pick {
+        /// Project name to open directly.
+        project: Option<String>,
+        /// Session template override used only when opening a project.
+        #[arg(short = 's', long = "session")]
+        session: Option<String>,
+    },
     /// Manage configured projects
     Project {
         /// Project subcommand to run.
@@ -89,7 +95,9 @@ pub fn run() -> Result<()> {
             tmux::list_sessions(false, true)?;
             Ok(())
         }
-        Commands::Pick => sessions::pick(),
+        Commands::Pick { project, session } => {
+            sessions::pick(project.as_deref(), session.as_deref())
+        }
         Commands::Project { command } => match command {
             ProjectCommands::List => {
                 projects::list_projects();

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -1,6 +1,8 @@
-use anyhow::{Result, anyhow, bail};
+use std::fs;
 
-use crate::{config, fzf, git, tmux};
+use anyhow::{Context, Result, anyhow, bail};
+
+use crate::{Config, ResolvedProject, SessionConfig, config, fzf, git, tmux};
 
 pub fn list_projects() {
     let config = config::config();
@@ -37,37 +39,17 @@ pub fn load_project(
             anyhow!("Session template \"{template_name}\" is not configured")
         })?;
 
-    if !project.path.exists() {
-        bail!(
-            "Project \"{}\" path {} does not exist; configured repository is {}",
-            project.name,
-            project.path.display(),
-            project.repository
-        );
+    validate_project_path(&project)?;
+
+    match worktree {
+        Some(branch) => open_project_branch(config, &project, template, branch)?,
+        None => tmux::open_session(&project.name, &project.path, template)?,
     }
 
-    if !project.path.is_dir() {
-        bail!(
-            "Project \"{}\" path {} is not a directory; configured repository is {}",
-            project.name,
-            project.path.display(),
-            project.repository
-        );
-    }
-
-    let (root, tmux_name) = match worktree {
-        Some(branch) => {
-            let worktree = git::find_worktree(&project.path, branch)?;
-            (worktree.path, format!("{}--{branch}", project.name))
-        }
-        None => (project.path.clone(), project.name.clone()),
-    };
-
-    tmux::open_session(&tmux_name, &root, template)?;
     Ok(())
 }
 
-pub fn open_project_interactive(project_name: &str) -> Result<()> {
+pub fn open_project_interactive(project_name: &str, session_override: Option<&str>) -> Result<()> {
     tmux::err_in_tmux()?;
 
     let config = config::config();
@@ -76,9 +58,29 @@ pub fn open_project_interactive(project_name: &str) -> Result<()> {
         .ok_or_else(|| anyhow!("Project \"{project_name}\" is not configured"))?;
 
     let template = config
-        .project_session_template(&project, None)
-        .ok_or_else(|| anyhow!("Project default session template is not configured"))?;
+        .project_session_template(&project, session_override)
+        .ok_or_else(|| {
+            let template_name = session_override.unwrap_or("<project default>");
+            anyhow!("Session template \"{template_name}\" is not configured")
+        })?;
 
+    validate_project_path(&project)?;
+
+    let branches = git::list_local_branches(&project.path)?;
+    if branches.is_empty() {
+        tmux::open_session(&project.name, &project.path, template)?;
+        return Ok(());
+    }
+
+    let Some(branch) = fzf::select(branches, "branch> ")? else {
+        return Ok(());
+    };
+
+    open_project_branch(config, &project, template, &branch)?;
+    Ok(())
+}
+
+fn validate_project_path(project: &ResolvedProject) -> Result<()> {
     if !project.path.exists() {
         bail!(
             "Project \"{}\" path {} does not exist; configured repository is {}",
@@ -97,28 +99,47 @@ pub fn open_project_interactive(project_name: &str) -> Result<()> {
         );
     }
 
-    let worktrees = git::list_worktrees(&project.path)?;
-    if !git::has_additional_worktrees(&project.path, &worktrees) {
-        tmux::open_session(&project.name, &project.path, template)?;
-        return Ok(());
+    Ok(())
+}
+
+fn open_project_branch(
+    config: &Config,
+    project: &ResolvedProject,
+    template: &SessionConfig,
+    branch: &str,
+) -> Result<()> {
+    let branches = git::list_local_branches(&project.path)?;
+    if !branches.iter().any(|candidate| candidate == branch) {
+        bail!(
+            "Branch \"{}\" is not a local branch for project \"{}\"",
+            branch,
+            project.name
+        );
     }
 
-    let branch_worktrees = git::branch_worktree_choices(&worktrees);
-    let branch_names = branch_worktrees
-        .iter()
-        .map(|(branch, _)| branch.clone())
-        .collect::<Vec<_>>();
-
-    let Some(branch) = fzf::select(branch_names, "worktree> ")? else {
-        return Ok(());
+    let worktrees = git::list_worktrees(&project.path)?;
+    let root = if let Some(worktree) = git::worktree_for_branch(&worktrees, branch) {
+        worktree.path
+    } else {
+        let worktree_path = git::managed_worktree_path_for_branch(
+            &config.worktrees_dir,
+            &project.name,
+            branch,
+            &worktrees,
+        )?;
+        if let Some(parent) = worktree_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create managed worktree directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        git::create_worktree(&project.path, &worktree_path, branch)?;
+        worktree_path
     };
 
-    let root = branch_worktrees
-        .into_iter()
-        .find_map(|(candidate, path)| (candidate == branch).then_some(path))
-        .ok_or_else(|| anyhow!("Selected unknown worktree branch \"{branch}\""))?;
     let tmux_name = format!("{}--{branch}", project.name);
-
     tmux::open_session(&tmux_name, &root, template)?;
     Ok(())
 }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -13,13 +13,20 @@ enum PickTarget {
     Project(String),
 }
 
-pub fn pick() -> Result<()> {
+pub fn pick(project: Option<&str>, session_override: Option<&str>) -> Result<()> {
+    if let Some(project) = project {
+        projects::open_project_interactive(project, session_override)?;
+        return Ok(());
+    }
+
     match pick_target()? {
         Some(PickTarget::TmuxSession(name)) => {
             tmux::err_in_tmux()?;
             tmux::attach(&name)?;
         }
-        Some(PickTarget::Project(name)) => projects::open_project_interactive(&name)?,
+        Some(PickTarget::Project(name)) => {
+            projects::open_project_interactive(&name, session_override)?;
+        }
         None => {}
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -34,9 +34,81 @@ pub enum GitError {
         /// Project path that was searched.
         project_path: PathBuf,
     },
+    /// The branch cannot be converted into a managed worktree path segment.
+    #[error("Branch \"{0}\" cannot be used as a managed worktree path segment")]
+    InvalidManagedWorktreeBranch(String),
+    /// The managed worktree path exists but belongs to another checkout.
+    #[error("Managed worktree path {} already exists but is not registered for branch \"{branch}\"", path.display())]
+    ManagedWorktreePathConflict {
+        /// Existing path that would be reused for the managed worktree.
+        path: PathBuf,
+        /// Branch that was requested.
+        branch: String,
+    },
     /// git worktree output could not be parsed.
     #[error("{0}")]
     Parse(String),
+}
+
+/// Lists local branch names for `project_path`, sorted by git.
+///
+/// # Errors
+///
+/// Returns an error if `project_path` does not exist or git fails.
+pub fn list_local_branches(project_path: &Path) -> Result<Vec<String>, GitError> {
+    if !project_path.exists() {
+        return Err(GitError::MissingProjectPath(project_path.to_owned()));
+    }
+
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"])
+        .output()
+        .map_err(GitError::Io)?;
+
+    let combined = {
+        let mut s = String::from_utf8_lossy(&output.stdout).into_owned();
+        s.push_str(&String::from_utf8_lossy(&output.stderr));
+        s
+    };
+
+    if !output.status.success() {
+        return Err(GitError::Command(combined));
+    }
+
+    Ok(parse_local_branches(&combined))
+}
+
+/// Creates a git worktree for `branch` at `worktree_path`.
+///
+/// # Errors
+///
+/// Returns an error if git fails.
+pub fn create_worktree(
+    project_path: &Path,
+    worktree_path: &Path,
+    branch: &str,
+) -> Result<(), GitError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .args(["worktree", "add"])
+        .arg(worktree_path)
+        .arg(branch)
+        .output()
+        .map_err(GitError::Io)?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let combined = {
+        let mut s = String::from_utf8_lossy(&output.stdout).into_owned();
+        s.push_str(&String::from_utf8_lossy(&output.stderr));
+        s
+    };
+    Err(GitError::Command(combined))
 }
 
 /// Lists all git worktrees for `project_path`.
@@ -79,6 +151,15 @@ pub fn find_worktree(project_path: &Path, branch: &str) -> Result<Worktree, GitE
     find_worktree_in(list_worktrees(project_path)?, project_path, branch)
 }
 
+/// Finds the worktree for `branch` in an already-discovered worktree list.
+#[must_use]
+pub fn worktree_for_branch(worktrees: &[Worktree], branch: &str) -> Option<Worktree> {
+    worktrees
+        .iter()
+        .find(|worktree| worktree.branch.as_deref() == Some(branch))
+        .cloned()
+}
+
 fn find_worktree_in(
     worktrees: Vec<Worktree>,
     project_path: &Path,
@@ -117,6 +198,17 @@ fn parse_worktrees(input: &str) -> Result<Vec<Worktree>, GitError> {
 
     push_worktree(&mut worktrees, current_path.take(), current_branch.take())?;
     Ok(worktrees)
+}
+
+fn parse_local_branches(input: &str) -> Vec<String> {
+    let mut branches = input
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    branches.sort();
+    branches
 }
 
 fn push_worktree(
@@ -169,6 +261,78 @@ pub fn branch_worktree_choices(worktrees: &[Worktree]) -> Vec<(String, PathBuf)>
         .collect::<Vec<_>>();
     choices.sort_by(|(left, _), (right, _)| left.cmp(right));
     choices
+}
+
+/// Returns the managed worktree path for `project_name` and `branch`.
+///
+/// # Errors
+///
+/// Returns an error when `branch` cannot produce a non-empty path segment.
+pub fn managed_worktree_path(
+    worktrees_dir: &Path,
+    project_name: &str,
+    branch: &str,
+) -> Result<PathBuf, GitError> {
+    let branch_segment = sanitized_branch_segment(branch);
+    if branch_segment.is_empty() {
+        return Err(GitError::InvalidManagedWorktreeBranch(branch.to_owned()));
+    }
+
+    Ok(worktrees_dir.join(project_name).join(branch_segment))
+}
+
+/// Returns a managed worktree path and rejects path collisions.
+///
+/// # Errors
+///
+/// Returns an error if the branch path cannot be generated or if an existing
+/// path is not already registered as `branch`'s worktree.
+pub fn managed_worktree_path_for_branch(
+    worktrees_dir: &Path,
+    project_name: &str,
+    branch: &str,
+    worktrees: &[Worktree],
+) -> Result<PathBuf, GitError> {
+    let path = managed_worktree_path(worktrees_dir, project_name, branch)?;
+
+    if path.exists()
+        && !worktrees.iter().any(|worktree| {
+            same_path(&worktree.path, &path) && worktree.branch.as_deref() == Some(branch)
+        })
+    {
+        return Err(GitError::ManagedWorktreePathConflict {
+            path,
+            branch: branch.to_owned(),
+        });
+    }
+
+    Ok(path)
+}
+
+fn sanitized_branch_segment(input: &str) -> String {
+    let mut sanitized = String::new();
+    let mut last_was_underscore = false;
+
+    for ch in input.trim().chars() {
+        let next = if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            ch
+        } else {
+            '_'
+        };
+
+        if next == '_' {
+            if last_was_underscore {
+                continue;
+            }
+            last_was_underscore = true;
+        } else {
+            last_was_underscore = false;
+        }
+
+        sanitized.push(next);
+    }
+
+    sanitized
 }
 
 #[cfg(test)]
@@ -260,6 +424,75 @@ detached
         .expect_err("missing branch should return an error");
 
         assert!(err.to_string().contains("feature/foo"));
+    }
+
+    #[test]
+    fn parses_and_sorts_local_branches() {
+        let branches = parse_local_branches(
+            "\
+zeta
+feature/foo
+
+main
+",
+        );
+
+        assert_eq!(branches, vec!["feature/foo", "main", "zeta"]);
+    }
+
+    #[test]
+    fn parses_empty_local_branch_list() {
+        assert!(parse_local_branches("\n").is_empty());
+    }
+
+    #[test]
+    fn worktree_for_branch_matches_exact_branch() {
+        let worktrees = vec![
+            worktree("/repo", Some("main")),
+            worktree("/repo-feature", Some("feature/foo")),
+            worktree("/repo-featured", Some("feature")),
+        ];
+
+        let found =
+            worktree_for_branch(&worktrees, "feature/foo").expect("branch worktree should exist");
+
+        assert_eq!(found.path, PathBuf::from("/repo-feature"));
+    }
+
+    #[test]
+    fn generates_managed_worktree_path() {
+        let path = managed_worktree_path(Path::new("/worktrees"), "alpha", "feature/foo")
+            .expect("managed path should be generated");
+
+        assert_eq!(path, PathBuf::from("/worktrees/alpha/feature_foo"));
+    }
+
+    #[test]
+    fn rejects_empty_managed_worktree_path_segment() {
+        let err = managed_worktree_path(Path::new("/worktrees"), "alpha", "   ")
+            .expect_err("empty branch should be rejected");
+
+        assert!(matches!(err, GitError::InvalidManagedWorktreeBranch(_)));
+    }
+
+    #[test]
+    fn rejects_existing_unregistered_managed_worktree_path() {
+        let root = std::env::temp_dir().join(format!(
+            "piquel-git-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time should be valid")
+                .as_nanos()
+        ));
+        let existing = root.join("alpha/feature_foo");
+        std::fs::create_dir_all(&existing).expect("test directory should be created");
+
+        let err = managed_worktree_path_for_branch(&root, "alpha", "feature/foo", &[])
+            .expect_err("existing unregistered path should be rejected");
+
+        assert!(matches!(err, GitError::ManagedWorktreePathConflict { .. }));
+
+        std::fs::remove_dir_all(root).expect("test directory should be removed");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,8 @@ pub enum ProjectSessionConfig {
 pub struct Config {
     #[serde(default = "default_projects_dir")]
     projects_dir: PathBuf,
+    #[serde(default = "default_worktrees_dir")]
+    worktrees_dir: PathBuf,
     #[serde(default = "default_default_session")]
     default_session: String,
     #[serde(default)]
@@ -132,6 +134,7 @@ impl Config {
     /// default-session references are invalid.
     pub fn validate_and_normalize(&mut self) -> Result<(), ConfigError> {
         self.projects_dir = expand_home(&self.projects_dir);
+        self.worktrees_dir = expand_home(&self.worktrees_dir);
 
         for (name, session) in &self.sessions {
             session.validate(name)?;
@@ -250,6 +253,10 @@ fn default_projects_dir() -> PathBuf {
     PathBuf::from("~/Projects")
 }
 
+fn default_worktrees_dir() -> PathBuf {
+    PathBuf::from("~/.piquel/worktrees")
+}
+
 fn default_default_session() -> String {
     "default".to_owned()
 }
@@ -290,6 +297,7 @@ mod tests {
     fn config_with_default() -> Config {
         Config {
             projects_dir: PathBuf::from("~/Projects"),
+            worktrees_dir: PathBuf::from("~/.piquel/worktrees"),
             default_session: "default".to_owned(),
             sessions: HashMap::from([("default".to_owned(), session())]),
             projects: vec![],
@@ -297,7 +305,7 @@ mod tests {
     }
 
     #[test]
-    fn expands_projects_dir_and_project_path() {
+    fn expands_projects_dir_worktrees_dir_and_project_path() {
         let home = std::env::home_dir().expect("HOME should be set for tests");
         let mut config = config_with_default();
         config.projects.push(ProjectConfig {
@@ -312,7 +320,28 @@ mod tests {
             .expect("config should validate");
 
         assert_eq!(config.projects_dir, home.join("Projects"));
+        assert_eq!(config.worktrees_dir, home.join(".piquel/worktrees"));
         assert_eq!(config.projects[0].path, Some(home.join("src/repo")));
+    }
+
+    #[test]
+    fn worktrees_dir_defaults_and_expands_from_json_config() {
+        let home = std::env::home_dir().expect("HOME should be set for tests");
+        let mut config = serde_json::from_str::<Config>(
+            r#"{
+                "default_session": "default",
+                "sessions": {
+                    "default": { "windows": [{ "commands": [] }] }
+                }
+            }"#,
+        )
+        .expect("config should parse");
+
+        config
+            .validate_and_normalize()
+            .expect("config should validate");
+
+        assert_eq!(config.worktrees_dir, home.join(".piquel/worktrees"));
     }
 
     #[test]
@@ -342,6 +371,7 @@ mod tests {
     fn missing_global_default_session_fails_validation() {
         let mut config = Config {
             projects_dir: PathBuf::from("~/Projects"),
+            worktrees_dir: PathBuf::from("~/.piquel/worktrees"),
             default_session: "missing".to_owned(),
             sessions: HashMap::from([("default".to_owned(), session())]),
             projects: vec![],
@@ -354,6 +384,7 @@ mod tests {
     fn empty_session_template_windows_fail_validation() {
         let mut config = Config {
             projects_dir: PathBuf::from("~/Projects"),
+            worktrees_dir: PathBuf::from("~/.piquel/worktrees"),
             default_session: "default".to_owned(),
             sessions: HashMap::from([("default".to_owned(), SessionConfig { windows: vec![] })]),
             projects: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,14 @@ fn repository_basename(repository: &str) -> Result<String, ConfigError> {
 }
 
 fn validate_project_name(name: &str) -> Result<(), ConfigError> {
-    if name.trim().is_empty() || name.contains(':') {
+    let trimmed = name.trim();
+    if trimmed.is_empty()
+        || trimmed == "."
+        || trimmed == ".."
+        || name.contains(':')
+        || name.contains('/')
+        || name.contains('\\')
+    {
         return Err(ConfigError::Validation(format!(
             "\"{name}\" is not a valid project name"
         )));
@@ -363,6 +370,31 @@ mod tests {
                     .resolved_name()
                     .expect("project name should resolve"),
                 expected
+            );
+        }
+    }
+
+    #[test]
+    fn project_names_must_be_safe_path_segments() {
+        for name in [
+            "",
+            "   ",
+            ".",
+            "..",
+            "owner/repo",
+            r"owner\repo",
+            "repo:name",
+        ] {
+            let project = ProjectConfig {
+                repository: "https://github.com/owner/repo.git".to_owned(),
+                name: Some(name.to_owned()),
+                path: None,
+                default_session: None,
+            };
+
+            assert!(
+                project.resolved_name().is_err(),
+                "{name:?} should be rejected"
             );
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,6 +2,7 @@
 
 use std::{
     ffi::OsStr,
+    fmt::Write as _,
     fs,
     path::{Path, PathBuf},
     process::{Command, Output},
@@ -165,11 +166,84 @@ printf '%s\n' {}
     )
 }
 
-fn fake_git_worktree_script(main_path: &Path, branch_path: &Path) -> String {
+fn fake_fzf_sequence_script(selections: &[&str], state: &Path, input_prefix: &Path) -> String {
+    let mut cases = String::new();
+    for (index, selection) in selections.iter().enumerate() {
+        writeln!(
+            cases,
+            "{}) printf '%s\\n' {} ;;",
+            index + 1,
+            shell_quote(selection)
+        )
+        .expect("writing to string should succeed");
+    }
+
     format!(
         r#"#!{}
+state={}
+prefix={}
+count=0
+if [ -f "$state" ]; then
+    count=$(cat "$state")
+fi
+next=$((count + 1))
+printf '%s\n' "$next" > "$state"
+cat > "$prefix.$next"
+case "$next" in
+{}    *) exit 130 ;;
+esac
+"#,
+        path_str(&shell_path()),
+        shell_quote(path_str(state)),
+        shell_quote(path_str(input_prefix)),
+        cases
+    )
+}
+
+fn fake_git_script(branches: &str, worktrees: &str, add_log: Option<&Path>) -> String {
+    let add_log = add_log.map_or_else(
+        || ":".to_owned(),
+        |path| {
+            format!(
+                "log={}\nprintf '%s\\n' \"$*\" >> \"$log\"",
+                shell_quote(path_str(path))
+            )
+        },
+    );
+
+    format!(
+        r#"#!{}
+if [ "$1" = "-C" ] && [ "$3" = "for-each-ref" ]; then
+    cat <<'EOF'
+{}EOF
+    exit 0
+fi
+
 if [ "$1" = "-C" ] && [ "$3" = "worktree" ] && [ "$4" = "list" ] && [ "$5" = "--porcelain" ]; then
     cat <<'EOF'
+{}EOF
+    exit 0
+fi
+
+if [ "$1" = "-C" ] && [ "$3" = "worktree" ] && [ "$4" = "add" ]; then
+    {}
+    exit 0
+fi
+
+exit 64
+"#,
+        path_str(&shell_path()),
+        branches,
+        worktrees,
+        add_log
+    )
+}
+
+fn fake_git_worktree_script(main_path: &Path, branch_path: &Path) -> String {
+    fake_git_script(
+        "main\nfeature/foo\n",
+        &format!(
+            "\
 worktree {}
 HEAD 1111111111111111111111111111111111111111
 branch refs/heads/main
@@ -178,15 +252,11 @@ worktree {}
 HEAD 2222222222222222222222222222222222222222
 branch refs/heads/feature/foo
 
-EOF
-    exit 0
-fi
-
-exit 64
-"#,
-        path_str(&shell_path()),
-        path_str(main_path),
-        path_str(branch_path)
+",
+            path_str(main_path),
+            path_str(branch_path)
+        ),
+        None,
     )
 }
 
@@ -225,6 +295,42 @@ where
     S: AsRef<OsStr>,
 {
     piquel().args(args).output().expect("piquel should run")
+}
+
+fn config_for_alpha_project(
+    temp: &TestDir,
+    project_path: &Path,
+    worktrees_dir: Option<&Path>,
+) -> PathBuf {
+    let worktrees_dir_field = worktrees_dir.map_or_else(String::new, |path| {
+        format!(
+            r#""worktrees_dir": {},
+            "#,
+            serde_json::to_string(path_str(path)).expect("path should serialize")
+        )
+    });
+
+    write_config(
+        temp,
+        &format!(
+            r#"{{
+                "projects_dir": "/tmp/projects",
+                {}"default_session": "default",
+                "sessions": {{
+                    "default": {{ "windows": [{{ "commands": ["default cmd"] }}] }},
+                    "rust": {{ "windows": [{{ "commands": ["cargo check"] }}] }}
+                }},
+                "projects": [
+                    {{
+                        "repository": "https://github.com/owner/alpha.git",
+                        "path": {}
+                    }}
+                ]
+            }}"#,
+            worktrees_dir_field,
+            serde_json::to_string(path_str(project_path)).expect("path should serialize")
+        ),
+    )
 }
 
 #[test]
@@ -444,6 +550,70 @@ fn project_load_worktree_opens_requested_branch_worktree() {
 }
 
 #[test]
+fn project_load_worktree_creates_missing_managed_worktree() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    let worktrees_dir = temp.path().join("managed-worktrees");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    let config = config_for_alpha_project(&temp, &project_path, Some(&worktrees_dir));
+    let tmux_log = temp.path().join("tmux.log");
+    let git_add_log = temp.path().join("git-add.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "")),
+            (
+                "git",
+                fake_git_script(
+                    "main\nfeature/foo\n",
+                    &format!(
+                        "\
+worktree {}
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+",
+                        path_str(&project_path)
+                    ),
+                    Some(&git_add_log),
+                ),
+            ),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args([
+            "--config",
+            path_str(&config),
+            "project",
+            "load",
+            "alpha",
+            "--worktree",
+            "feature/foo",
+        ])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let managed_path = worktrees_dir.join("alpha/feature_foo");
+    let git_log = fs::read_to_string(git_add_log).expect("git add log should be readable");
+    assert!(git_log.contains(&format!(
+        "-C {} worktree add {} feature/foo",
+        path_str(&project_path),
+        path_str(&managed_path)
+    )));
+
+    let tmux_log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(tmux_log.contains(&format!(
+        "new-session -d -c {} -s alpha--feature_foo",
+        path_str(&managed_path)
+    )));
+}
+
+#[test]
 fn pick_routes_fzf_tmux_selection_to_attach() {
     let temp = TestDir::new();
     let config = config_with_projects(&temp);
@@ -472,4 +642,314 @@ fn pick_routes_fzf_tmux_selection_to_attach() {
     let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
     assert!(log.contains("list-sessions -F #{session_name}"));
     assert!(log.contains("attach -t beta"));
+}
+
+#[test]
+fn pick_with_session_still_attaches_selected_tmux_session_unchanged() {
+    let temp = TestDir::new();
+    let config = config_with_projects(&temp);
+    let tmux_log = temp.path().join("tmux.log");
+    let fzf_input = temp.path().join("fzf-input.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "beta\n")),
+            ("fzf", fake_fzf_script("beta", &fzf_input)),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "pick", "--session", "rust"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(log.contains("attach -t beta"));
+    assert!(!log.contains("cargo check"));
+}
+
+#[test]
+fn pick_project_argument_skips_first_picker_and_shows_branch_picker() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    let worktree_path = temp.path().join("worktrees/alpha-feature");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    fs::create_dir_all(&worktree_path).expect("worktree path should be created");
+    let config = config_for_alpha_project(&temp, &project_path, None);
+    let tmux_log = temp.path().join("tmux.log");
+    let fzf_input = temp.path().join("fzf-input.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "")),
+            ("fzf", fake_fzf_script("feature/foo", &fzf_input)),
+            (
+                "git",
+                fake_git_worktree_script(&project_path, &worktree_path),
+            ),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "pick", "alpha"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let fzf_items = fs::read_to_string(fzf_input).expect("fzf input should be readable");
+    assert_eq!(fzf_items, "feature/foo\nmain\n");
+
+    let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(log.contains(&format!(
+        "new-session -d -c {} -s alpha--feature_foo",
+        path_str(&worktree_path)
+    )));
+}
+
+#[test]
+fn pick_project_branch_checked_out_at_project_path_uses_branch_session_name() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    let config = config_for_alpha_project(&temp, &project_path, None);
+    let tmux_log = temp.path().join("tmux.log");
+    let fzf_input = temp.path().join("fzf-input.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "")),
+            ("fzf", fake_fzf_script("main", &fzf_input)),
+            (
+                "git",
+                fake_git_script(
+                    "main\n",
+                    &format!(
+                        "\
+worktree {}
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+",
+                        path_str(&project_path)
+                    ),
+                    None,
+                ),
+            ),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "pick", "alpha"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(log.contains(&format!(
+        "new-session -d -c {} -s alpha--main",
+        path_str(&project_path)
+    )));
+}
+
+#[test]
+fn pick_project_with_no_local_branches_opens_project_session() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    let config = config_for_alpha_project(&temp, &project_path, None);
+    let tmux_log = temp.path().join("tmux.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "")),
+            ("git", fake_git_script("", "", None)),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "pick", "alpha"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(log.contains(&format!(
+        "new-session -d -c {} -s alpha",
+        path_str(&project_path)
+    )));
+}
+
+#[test]
+fn pick_project_missing_branch_worktree_runs_git_worktree_add() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    let worktrees_dir = temp.path().join("managed-worktrees");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    let config = config_for_alpha_project(&temp, &project_path, Some(&worktrees_dir));
+    let tmux_log = temp.path().join("tmux.log");
+    let fzf_input = temp.path().join("fzf-input.log");
+    let git_add_log = temp.path().join("git-add.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "")),
+            ("fzf", fake_fzf_script("feature/foo", &fzf_input)),
+            (
+                "git",
+                fake_git_script(
+                    "main\nfeature/foo\n",
+                    &format!(
+                        "\
+worktree {}
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+",
+                        path_str(&project_path)
+                    ),
+                    Some(&git_add_log),
+                ),
+            ),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "pick", "alpha"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let managed_path = worktrees_dir.join("alpha/feature_foo");
+    let git_log = fs::read_to_string(git_add_log).expect("git add log should be readable");
+    assert!(git_log.contains(&format!(
+        "-C {} worktree add {} feature/foo",
+        path_str(&project_path),
+        path_str(&managed_path)
+    )));
+}
+
+#[test]
+fn pick_session_override_applies_to_project_created_session() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    let config = config_for_alpha_project(&temp, &project_path, None);
+    let tmux_log = temp.path().join("tmux.log");
+    let fzf_input = temp.path().join("fzf-input.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "")),
+            ("fzf", fake_fzf_script("main", &fzf_input)),
+            (
+                "git",
+                fake_git_script(
+                    "main\n",
+                    &format!(
+                        "\
+worktree {}
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+",
+                        path_str(&project_path)
+                    ),
+                    None,
+                ),
+            ),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args([
+            "--config",
+            path_str(&config),
+            "pick",
+            "alpha",
+            "--session",
+            "rust",
+        ])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(log.contains("send-keys -t window-id cargo check Enter"));
+    assert!(!log.contains("send-keys -t window-id default cmd Enter"));
+}
+
+#[test]
+fn pick_session_override_applies_after_selecting_project_from_first_picker() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    let config = config_for_alpha_project(&temp, &project_path, None);
+    let tmux_log = temp.path().join("tmux.log");
+    let fzf_state = temp.path().join("fzf-state");
+    let fzf_prefix = temp.path().join("fzf-input");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "")),
+            (
+                "fzf",
+                fake_fzf_sequence_script(&["alpha", "main"], &fzf_state, &fzf_prefix),
+            ),
+            (
+                "git",
+                fake_git_script(
+                    "main\n",
+                    &format!(
+                        "\
+worktree {}
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+",
+                        path_str(&project_path)
+                    ),
+                    None,
+                ),
+            ),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "pick", "--session", "rust"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let first_input =
+        fs::read_to_string(fzf_prefix.with_extension("1")).expect("first fzf input readable");
+    let second_input =
+        fs::read_to_string(fzf_prefix.with_extension("2")).expect("second fzf input readable");
+    assert_eq!(first_input, "alpha\n");
+    assert_eq!(second_input, "main\n");
+
+    let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(log.contains("send-keys -t window-id cargo check Enter"));
+    assert!(!log.contains("send-keys -t window-id default cmd Enter"));
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -375,6 +375,31 @@ fn invalid_config_schema_exits_with_parse_error() {
 }
 
 #[test]
+fn unsafe_project_name_exits_with_validation_error() {
+    let temp = TestDir::new();
+    let config = write_config(
+        &temp,
+        r#"{
+            "projects_dir": "/tmp/projects",
+            "default_session": "default",
+            "sessions": {
+                "default": { "windows": [{ "commands": [] }] }
+            },
+            "projects": [
+                {
+                    "repository": "https://github.com/owner/alpha.git",
+                    "name": "../alpha"
+                }
+            ]
+        }"#,
+    );
+
+    let output = run(["--config", path_str(&config), "project", "list"]);
+
+    assert_failure(&output, &["\"../alpha\" is not a valid project name"]);
+}
+
+#[test]
 fn project_load_rejects_missing_project_path_before_opening_tmux_session() {
     let temp = TestDir::new();
     let config = write_config(


### PR DESCRIPTION
## Summary
- Add branch-aware project picking that can skip the initial project/session chooser when `piquel pick <project>` is used.
- Manage local branches through git worktrees, creating a managed worktree under `worktrees_dir` when a branch does not already have one.
- Preserve existing tmux session behavior for direct session selection, while allowing session template overrides only when opening projects.
- Add `worktrees_dir` config support and document the new branch/worktree workflow in the README and Nix module.
- Expand CLI and integration coverage for branch selection, worktree creation, and session override behavior.