### PR TITLE
Add optional tmux window names

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ Fuller project config:
     "default": {
       "windows": [
         {
+          "name": "editor",
           "commands": ["vim ."]
         },
         {
+          "name": "git",
           "commands": ["git status"]
         }
       ]
@@ -116,9 +118,11 @@ Fuller project config:
     "rust": {
       "windows": [
         {
+          "name": "editor",
           "commands": ["vim ."]
         },
         {
+          "name": "test",
           "commands": ["cargo test"]
         }
       ]
@@ -136,6 +140,7 @@ Fuller project config:
       "default_session": {
         "windows": [
           {
+            "name": "editor",
             "commands": ["vim ."]
           }
         ]
@@ -161,13 +166,14 @@ Fields:
   `<projects_dir>/<project-name>`.
 - `projects[].default_session`: either the name of a global session template or
   an inline session template.
+- `sessions.*.windows[].name`: optional tmux window name.
 - `sessions.*.windows[].commands`: commands sent to the created tmux window,
   each followed by `Enter`.
 
 Project names must be safe path segments: they must not be empty, `.`, `..`, or
 contain `/`, `\`, or `:`. Session names must not be empty or contain `:`. tmux
 session names derived from worktree branches are sanitized before tmux is
-invoked.
+invoked. Window names, when set, must not be blank.
 
 ## Testing
 

--- a/examples/test-config.json
+++ b/examples/test-config.json
@@ -6,11 +6,13 @@
         "default": {
             "windows": [
                 {
+                    "name": "editor",
                     "commands": [
                         "vim ."
                     ]
                 },
                 {
+                    "name": "git",
                     "commands": [
                         "git pull"
                     ]
@@ -20,11 +22,13 @@
         "rust": {
             "windows": [
                 {
+                    "name": "editor",
                     "commands": [
                         "vim ."
                     ]
                 },
                 {
+                    "name": "rust",
                     "commands": [
                         "git pull",
                         "cargo clippy"
@@ -39,11 +43,13 @@
             "default_session": {
                 "windows": [
                     {
+                        "name": "editor",
                         "commands": [
                             "vim ."
                         ]
                     },
                     {
+                        "name": "rust",
                         "commands": [
                             "git pull",
                             "cargo clippy"

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -49,6 +49,11 @@ in
 
             windowConfigType = types.submodule {
               options = {
+                name = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = "Optional tmux window name.";
+                };
                 commands = mkOption {
                   type = types.listOf types.str;
                   default = [ ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,26 @@ use crate::config::ConfigError;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct WindowConfig {
+    name: Option<String>,
     #[serde(default)]
     commands: Vec<String>,
+}
+
+impl WindowConfig {
+    fn validate(&self, session_name: &str, index: usize) -> Result<(), config::ConfigError> {
+        if self
+            .name
+            .as_ref()
+            .is_some_and(|name| name.trim().is_empty())
+        {
+            return Err(ConfigError::Validation(format!(
+                "Window {} in session template \"{session_name}\" has an empty name. If you don't want to specify a name, remove the field.",
+                index + 1
+            )));
+        }
+
+        Ok(())
+    }
 }
 
 /// Configuration for a tmux session template.
@@ -46,6 +64,10 @@ impl SessionConfig {
             return Err(ConfigError::Validation(format!(
                 "Session template \"{name}\" must have at least one window"
             )));
+        }
+
+        for (index, window) in self.windows.iter().enumerate() {
+            window.validate(name, index)?;
         }
 
         Ok(())
@@ -292,7 +314,10 @@ mod tests {
     use super::*;
 
     fn window() -> WindowConfig {
-        WindowConfig { commands: vec![] }
+        WindowConfig {
+            name: None,
+            commands: vec![],
+        }
     }
 
     fn session() -> SessionConfig {
@@ -468,6 +493,7 @@ mod tests {
             path: None,
             default_session: Some(ProjectSessionConfig::Inline(SessionConfig {
                 windows: vec![WindowConfig {
+                    name: None,
                     commands: vec!["cargo check".to_owned()],
                 }],
             })),
@@ -495,6 +521,22 @@ mod tests {
                 windows: vec![],
             })),
         });
+
+        assert!(config.validate_and_normalize().is_err());
+    }
+
+    #[test]
+    fn blank_window_names_fail_validation() {
+        let mut config = config_with_default();
+        config.sessions.insert(
+            "default".to_owned(),
+            SessionConfig {
+                windows: vec![WindowConfig {
+                    name: Some("   ".to_owned()),
+                    commands: vec![],
+                }],
+            },
+        );
 
         assert!(config.validate_and_normalize().is_err());
     }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -167,17 +167,17 @@ pub fn new_window(
     start_dir: &Path,
     window: &WindowConfig,
 ) -> Result<String, TmuxError> {
-    let window_id = exec_tmux_return(&[
-        "new-window",
-        "-P",
-        "-F",
-        "#{window_id}",
-        "-t",
-        session_name,
-        "-c",
-        &start_dir.to_string_lossy(),
-    ])
-    .map_err(|e| TmuxError::Command(format!("Failed to create window with error: {e}")))?;
+    let start_dir = start_dir.to_string_lossy();
+    let mut args = vec!["new-window", "-P", "-F", "#{window_id}"];
+
+    if let Some(name) = &window.name {
+        args.extend(["-n", name]);
+    }
+
+    args.extend(["-t", session_name, "-c", &start_dir]);
+
+    let window_id = exec_tmux_return(&args)
+        .map_err(|e| TmuxError::Command(format!("Failed to create window with error: {e}")))?;
 
     let window_id = window_id.trim_matches('\n').to_owned();
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -513,6 +513,50 @@ fn project_load_creates_tmux_session_from_configured_template() {
 }
 
 #[test]
+fn project_load_names_configured_tmux_windows() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    let tmux_log = temp.path().join("tmux.log");
+    let config = write_config(
+        &temp,
+        &format!(
+            r#"{{
+                "default_session": "default",
+                "sessions": {{
+                    "default": {{
+                        "windows": [
+                            {{ "name": "editor", "commands": ["vim ."] }}
+                        ]
+                    }}
+                }},
+                "projects": [
+                    {{
+                        "repository": "https://github.com/owner/alpha.git",
+                        "path": {}
+                    }}
+                ]
+            }}"#,
+            serde_json::to_string(path_str(&project_path)).expect("path should serialize")
+        ),
+    );
+    let bin = bin_dir_with(&temp, &[("tmux", fake_tmux_script(&tmux_log, ""))]);
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "project", "load", "alpha"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(log.contains("new-window -P -F #{window_id} -n editor -t alpha"));
+    assert!(log.contains("send-keys -t window-id vim . Enter"));
+}
+
+#[test]
 fn project_load_worktree_opens_requested_branch_worktree() {
     let temp = TestDir::new();
     let project_path = temp.path().join("projects/alpha");


### PR DESCRIPTION
## Summary
- Add an optional `name` field to window configs and plumb it through tmux window creation.
- Validate that configured window names are not blank, matching the existing config validation style.
- Update docs, example config, and Nix module options to describe the new field.
- Add CLI coverage for creating named tmux windows.