### PR TITLE
refactor: add CLI state object

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use crate::{config, tmux};
+use crate::{Config, config, tmux};
 
 mod projects;
 mod sessions;
@@ -74,6 +74,25 @@ pub enum ProjectCommands {
     },
 }
 
+/// Runtime state shared by CLI command handlers.
+pub struct State {
+    config: Config,
+}
+
+impl State {
+    /// Creates CLI state from loaded configuration.
+    #[must_use]
+    pub fn new(config: Config) -> Self {
+        Self { config }
+    }
+
+    /// Lists running tmux sessions.
+    pub fn list(&self) -> Result<()> {
+        tmux::list_sessions()?;
+        Ok(())
+    }
+}
+
 /// Parses CLI arguments, loads configuration, and dispatches the selected command.
 ///
 /// # Errors
@@ -95,31 +114,23 @@ pub fn run() -> Result<()> {
             Ok,
         )?;
 
-    config::load_config(&config_path)?;
+    let state = State::new(config::load_config(&config_path)?);
 
     match &cli.command {
-        Commands::List => {
-            tmux::list_sessions(false, true)?;
-            Ok(())
-        }
-        Commands::Pick { project, session } => {
-            sessions::pick(project.as_deref(), session.as_deref())
-        }
+        Commands::List => state.list(),
+        Commands::Pick { project, session } => state.pick(project.as_deref(), session.as_deref()),
         Commands::Project { command } => match command {
-            ProjectCommands::List => {
-                projects::list_projects();
-                Ok(())
-            }
+            ProjectCommands::List => state.list_projects(),
             ProjectCommands::Load {
                 project,
                 session,
                 worktree,
-            } => projects::load_project(project, session.as_deref(), worktree.as_deref()),
+            } => state.load_project(project, session.as_deref(), worktree.as_deref()),
         },
         Commands::Session {
             path,
             session,
             name,
-        } => sessions::session(path.clone(), session.as_deref(), name.as_deref()),
+        } => state.session(path.clone(), session.as_deref(), name.as_deref()),
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,6 +87,10 @@ impl State {
     }
 
     /// Lists running tmux sessions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if tmux session listing fails.
     pub fn list(&self) -> Result<()> {
         tmux::list_sessions()?;
         Ok(())

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -6,6 +6,11 @@ use crate::{Config, ResolvedProject, SessionConfig, cli::State, fzf, git, tmux};
 
 impl State {
     /// Lists configured projects.
+    ///
+    /// # Errors
+    ///
+    /// This currently does not fail, but returns `Result` to match CLI command
+    /// handler dispatch.
     pub fn list_projects(&self) -> Result<()> {
         let mut projects = self
             .config
@@ -25,6 +30,12 @@ impl State {
     }
 
     /// Loads a configured project, optionally opening a branch worktree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command is run inside tmux, the project or
+    /// session template is not configured, the project path is invalid, git
+    /// worktree setup fails, or tmux cannot open the session.
     pub fn load_project(
         &self,
         project_name: &str,
@@ -57,6 +68,13 @@ impl State {
     }
 
     /// Opens a configured project, prompting for a local branch when available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command is run inside tmux, the project or
+    /// session template is not configured, the project path is invalid, branch
+    /// selection fails, git worktree setup fails, or tmux cannot open the
+    /// session.
     pub fn open_project_interactive(
         &self,
         project_name: &str,

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -2,82 +2,96 @@ use std::fs;
 
 use anyhow::{Context, Result, anyhow, bail};
 
-use crate::{Config, ResolvedProject, SessionConfig, config, fzf, git, tmux};
+use crate::{Config, ResolvedProject, SessionConfig, cli::State, fzf, git, tmux};
 
-pub fn list_projects() {
-    let config = config::config();
-    let mut projects = config
-        .projects
-        .iter()
-        .filter_map(|project| project.resolved_name().ok())
-        .collect::<Vec<_>>();
+impl State {
+    /// Lists configured projects.
+    pub fn list_projects(&self) -> Result<()> {
+        let mut projects = self
+            .config
+            .projects
+            .iter()
+            .filter_map(|project| project.resolved_name().ok())
+            .collect::<Vec<_>>();
 
-    projects.sort();
-    projects.dedup();
+        projects.sort();
+        projects.dedup();
 
-    for project in projects {
-        println!("{project}");
-    }
-}
+        for project in projects {
+            println!("{project}");
+        }
 
-pub fn load_project(
-    project_name: &str,
-    session_override: Option<&str>,
-    worktree: Option<&str>,
-) -> Result<()> {
-    tmux::err_in_tmux()?;
-
-    let config = config::config();
-    let project = config
-        .project(project_name)
-        .ok_or_else(|| anyhow!("Project \"{project_name}\" is not configured"))?;
-
-    let template = config
-        .project_session_template(&project, session_override)
-        .ok_or_else(|| {
-            let template_name = session_override.unwrap_or("<project default>");
-            anyhow!("Session template \"{template_name}\" is not configured")
-        })?;
-
-    validate_project_path(&project)?;
-
-    match worktree {
-        Some(branch) => open_project_branch(config, &project, template, branch)?,
-        None => tmux::open_session(&project.name, &project.path, template)?,
+        Ok(())
     }
 
-    Ok(())
-}
+    /// Loads a configured project, optionally opening a branch worktree.
+    pub fn load_project(
+        &self,
+        project_name: &str,
+        session_override: Option<&str>,
+        worktree: Option<&str>,
+    ) -> Result<()> {
+        tmux::err_in_tmux()?;
 
-pub fn open_project_interactive(project_name: &str, session_override: Option<&str>) -> Result<()> {
-    tmux::err_in_tmux()?;
+        let project = self
+            .config
+            .project(project_name)
+            .ok_or_else(|| anyhow!("Project \"{project_name}\" is not configured"))?;
 
-    let config = config::config();
-    let project = config
-        .project(project_name)
-        .ok_or_else(|| anyhow!("Project \"{project_name}\" is not configured"))?;
+        let template = self
+            .config
+            .project_session_template(&project, session_override)
+            .ok_or_else(|| {
+                let template_name = session_override.unwrap_or("<project default>");
+                anyhow!("Session template \"{template_name}\" is not configured")
+            })?;
 
-    let template = config
-        .project_session_template(&project, session_override)
-        .ok_or_else(|| {
-            let template_name = session_override.unwrap_or("<project default>");
-            anyhow!("Session template \"{template_name}\" is not configured")
-        })?;
+        validate_project_path(&project)?;
 
-    validate_project_path(&project)?;
+        match worktree {
+            Some(branch) => open_project_branch(&self.config, &project, template, branch)?,
+            None => tmux::open_session(&project.name, &project.path, template)?,
+        }
 
-    let branches = git::list_local_branches(&project.path)?;
-    if branches.is_empty() {
-        tmux::open_session(&project.name, &project.path, template)?;
-        return Ok(());
+        Ok(())
     }
 
-    let Some(branch) = fzf::select(branches, "branch> ")? else {
-        return Ok(());
-    };
+    /// Opens a configured project, prompting for a local branch when available.
+    pub fn open_project_interactive(
+        &self,
+        project_name: &str,
+        session_override: Option<&str>,
+    ) -> Result<()> {
+        tmux::err_in_tmux()?;
 
-    open_project_branch(config, &project, template, &branch)?;
-    Ok(())
+        let project = self
+            .config
+            .project(project_name)
+            .ok_or_else(|| anyhow!("Project \"{project_name}\" is not configured"))?;
+
+        let template = self
+            .config
+            .project_session_template(&project, session_override)
+            .ok_or_else(|| {
+                let template_name = session_override.unwrap_or("<project default>");
+                anyhow!("Session template \"{template_name}\" is not configured")
+            })?;
+
+        validate_project_path(&project)?;
+
+        let branches = git::list_local_branches(&project.path)?;
+        if branches.is_empty() {
+            tmux::open_session(&project.name, &project.path, template)?;
+            return Ok(());
+        }
+
+        let Some(branch) = fzf::select(branches, "branch> ")? else {
+            return Ok(());
+        };
+
+        open_project_branch(&self.config, &project, template, &branch)?;
+        Ok(())
+    }
 }
 
 fn validate_project_path(project: &ResolvedProject) -> Result<()> {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 
-use crate::{cli::projects, config, fzf, tmux};
+use crate::{cli::State, fzf, tmux};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PickTarget {
@@ -13,63 +13,89 @@ enum PickTarget {
     Project(String),
 }
 
-pub fn pick(project: Option<&str>, session_override: Option<&str>) -> Result<()> {
-    if let Some(project) = project {
-        projects::open_project_interactive(project, session_override)?;
-        return Ok(());
-    }
-
-    match pick_target()? {
-        Some(PickTarget::TmuxSession(name)) => {
-            tmux::err_in_tmux()?;
-            tmux::attach(&name)?;
+impl State {
+    /// Picks a tmux session or configured project and opens it.
+    pub fn pick(&self, project: Option<&str>, session_override: Option<&str>) -> Result<()> {
+        if let Some(project) = project {
+            self.open_project_interactive(project, session_override)?;
+            return Ok(());
         }
-        Some(PickTarget::Project(name)) => {
-            projects::open_project_interactive(&name, session_override)?;
+
+        match self.pick_target()? {
+            Some(PickTarget::TmuxSession(name)) => {
+                tmux::err_in_tmux()?;
+                tmux::attach(&name)?;
+            }
+            Some(PickTarget::Project(name)) => {
+                self.open_project_interactive(&name, session_override)?;
+            }
+            None => {}
         }
-        None => {}
+
+        Ok(())
     }
 
-    Ok(())
-}
+    /// Opens an ad hoc directory with a configured session template.
+    pub fn session(
+        &self,
+        path: Option<PathBuf>,
+        session_override: Option<&str>,
+        name_override: Option<&str>,
+    ) -> Result<()> {
+        tmux::err_in_tmux()?;
 
-pub fn session(
-    path: Option<PathBuf>,
-    session_override: Option<&str>,
-    name_override: Option<&str>,
-) -> Result<()> {
-    tmux::err_in_tmux()?;
+        let template_name = session_override.unwrap_or(&self.config.default_session);
+        let template = self
+            .config
+            .session_template(template_name)
+            .ok_or_else(|| anyhow!("Session template \"{template_name}\" is not configured"))?;
 
-    let config = config::config();
-    let template_name = session_override.unwrap_or(&config.default_session);
-    let template = config
-        .session_template(template_name)
-        .ok_or_else(|| anyhow!("Session template \"{template_name}\" is not configured"))?;
+        let root = match path {
+            Some(path) => expand_home(&path),
+            None => std::env::current_dir().context("Failed to determine current directory")?,
+        };
 
-    let root = match path {
-        Some(path) => expand_home(&path),
-        None => std::env::current_dir().context("Failed to determine current directory")?,
-    };
+        if !root.exists() {
+            bail!("Session path {} does not exist", root.display());
+        }
 
-    if !root.exists() {
-        bail!("Session path {} does not exist", root.display());
+        if !root.is_dir() {
+            bail!("Session path {} is not a directory", root.display());
+        }
+
+        let tmux_name = match name_override {
+            Some(name) => name.to_owned(),
+            None => root
+                .file_name()
+                .ok_or_else(|| {
+                    anyhow!("Could not derive session name from path {}", root.display())
+                })?
+                .to_string_lossy()
+                .into_owned(),
+        };
+
+        tmux::open_session(&tmux_name, &root, template)?;
+        Ok(())
     }
 
-    if !root.is_dir() {
-        bail!("Session path {} is not a directory", root.display());
+    fn pick_target(&self) -> Result<Option<PickTarget>> {
+        let project_names = self
+            .config
+            .projects
+            .iter()
+            .filter_map(|project| project.resolved_name().ok());
+        let tmux_sessions = tmux::list_tmux_sessions()?;
+        let (items, mut targets) = build_pick_targets(tmux_sessions, project_names);
+
+        let Some(selection) = fzf::select(items, "piquel> ")? else {
+            return Ok(None);
+        };
+
+        targets
+            .remove(&selection)
+            .map(Some)
+            .ok_or_else(|| anyhow!("Selected unknown picker item \"{selection}\""))
     }
-
-    let tmux_name = match name_override {
-        Some(name) => name.to_owned(),
-        None => root
-            .file_name()
-            .ok_or_else(|| anyhow!("Could not derive session name from path {}", root.display()))?
-            .to_string_lossy()
-            .into_owned(),
-    };
-
-    tmux::open_session(&tmux_name, &root, template)?;
-    Ok(())
 }
 
 fn expand_home(path: &Path) -> PathBuf {
@@ -79,25 +105,6 @@ fn expand_home(path: &Path) -> PathBuf {
         return home.join(stripped);
     }
     path.to_path_buf()
-}
-
-fn pick_target() -> Result<Option<PickTarget>> {
-    let config = config::config();
-    let project_names = config
-        .projects
-        .iter()
-        .filter_map(|project| project.resolved_name().ok());
-    let tmux_sessions = tmux::list_tmux_sessions()?;
-    let (items, mut targets) = build_pick_targets(tmux_sessions, project_names);
-
-    let Some(selection) = fzf::select(items, "piquel> ")? else {
-        return Ok(None);
-    };
-
-    targets
-        .remove(&selection)
-        .map(Some)
-        .ok_or_else(|| anyhow!("Selected unknown picker item \"{selection}\""))
 }
 
 fn build_pick_targets<T, P>(

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -15,6 +15,11 @@ enum PickTarget {
 
 impl State {
     /// Picks a tmux session or configured project and opens it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if listing sessions, selecting an item, attaching to
+    /// tmux, opening a project, or creating a project worktree fails.
     pub fn pick(&self, project: Option<&str>, session_override: Option<&str>) -> Result<()> {
         if let Some(project) = project {
             self.open_project_interactive(project, session_override)?;
@@ -36,6 +41,12 @@ impl State {
     }
 
     /// Opens an ad hoc directory with a configured session template.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command is run inside tmux, the session template
+    /// is not configured, the target directory cannot be resolved or validated,
+    /// or tmux cannot open the session.
     pub fn session(
         &self,
         path: Option<PathBuf>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,19 +1,11 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::OnceLock,
-};
+use std::path::{Path, PathBuf};
 
 use crate::Config;
 use thiserror::Error;
 
-static CONFIG: OnceLock<Config> = OnceLock::new();
-
 /// Errors produced while loading or accessing the CLI config.
 #[derive(Debug, Error)]
 pub enum ConfigError {
-    /// The process-global config was already initialized.
-    #[error("Config has already been loaded")]
-    AlreadyLoaded,
     /// The configured JSON file could not be found or read.
     #[error("Config file {} does not exist", .0.display())]
     FileNotFound(PathBuf),
@@ -25,32 +17,17 @@ pub enum ConfigError {
     Validation(String),
 }
 
-/// Loads the JSON config from `config_path` into the global config store.
+/// Loads the JSON config from `config_path`.
 ///
 /// # Errors
 ///
-/// Returns an error if the config has already been loaded, the file cannot be
-/// read, the JSON cannot be parsed, or validation fails.
-pub fn load_config(config_path: &Path) -> Result<(), ConfigError> {
-    if CONFIG.get().is_some() {
-        return Err(ConfigError::AlreadyLoaded);
-    }
-
+/// Returns an error if the file cannot be read, the JSON cannot be parsed, or
+/// validation fails.
+pub fn load_config(config_path: &Path) -> Result<Config, ConfigError> {
     let config_file = std::fs::read_to_string(config_path)
         .map_err(|_| ConfigError::FileNotFound(config_path.to_owned()))?;
 
     let mut parsed: Config = serde_json::from_str(&config_file).map_err(ConfigError::ParseError)?;
     parsed.validate_and_normalize()?;
-
-    // `set` fails only if another thread raced us — treat that as already loaded.
-    CONFIG.set(parsed).map_err(|_| ConfigError::AlreadyLoaded)
-}
-
-/// Returns a reference to the global config.
-///
-/// # Panics
-///
-/// Panics if [`load_config`] has not been called successfully.
-pub fn config() -> &'static Config {
-    CONFIG.get().expect("Config has not been loaded yet")
+    Ok(parsed)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 /// Command-line parsing and top-level dispatch.
 pub mod cli;
-/// JSON config loading and global config access.
+/// JSON config loading.
 pub mod config;
 /// Interactive fuzzy selection helpers.
 pub mod fzf;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,4 +1,4 @@
-use crate::{SessionConfig, WindowConfig, config};
+use crate::{SessionConfig, WindowConfig};
 use std::io;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -21,28 +21,14 @@ pub enum TmuxError {
     InvalidSessionName(String),
 }
 
-/// Lists sessions from tmux, the config, or both, sorted and deduplicated.
+/// Lists running tmux sessions, sorted and deduplicated.
+/// Output is in stdout.
 ///
 /// # Errors
 ///
 /// Returns an error if tmux session listing fails.
-pub fn list_sessions(list_config: bool, list_tmux: bool) -> Result<(), TmuxError> {
-    let config = config::config();
-
-    let mut sessions: Vec<String> = Vec::new();
-
-    if list_tmux {
-        let tmux_sessions = list_tmux_sessions()?;
-        sessions.extend(tmux_sessions);
-    }
-
-    if list_config {
-        for project in &config.projects {
-            if let Ok(project_name) = project.resolved_name() {
-                sessions.push(project_name);
-            }
-        }
-    }
+pub fn list_sessions() -> Result<(), TmuxError> {
+    let mut sessions = list_tmux_sessions()?;
 
     sessions.sort();
     sessions.dedup();


### PR DESCRIPTION
## Summary
- Replace process-global config storage with a `State` object that owns the loaded `Config` and is used by CLI command handlers.
- Move project, picker, and ad hoc session command handling onto `State` while preserving the existing command flow and outputs.
- Simplify tmux session listing internals now that top-level `piquel list` only needs running tmux sessions.
- Keep config loading as a pure `load_config` operation that returns the parsed and normalized config instead of initializing global state.

## Behavior
- No intended CLI behavior changes.
- `piquel list` still lists running tmux sessions only.
- `piquel project list`, `piquel project load`, `piquel pick`, and `piquel session` continue to use the same config resolution, validation, tmux, git worktree, and picker flows.