### PR TITLE
feat: command executor abstraction for CLI, git, and tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ with `eprintln!`, and running `fzf` so the user can make a selection.
 When adding code, use this rule:
 
 - If the command is part of accomplishing the requested operation, create a
-  `CommandRequest` in the owning module, usually `tmux` or `git`, and execute it
-  through `State::executor()`.
+  `CommandRequest` in the owning module, usually `tmux` or `git`. Higher-level
+  wrappers that need to run several commands should stay in that owning module
+  and take `&dyn CommandExecutor` as a parameter.
 - If the action exists to show information to the user or ask the user for a
   choice, perform it directly in the local process or through the feedback
   module, such as `fzf::select`.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,32 @@ contain `/`, `\`, or `:`. Session names must not be empty or contain `:`. tmux
 session names derived from worktree branches are sanitized before tmux is
 invoked. Window names, when set, must not be blank.
 
+## Command Execution Model
+
+The CLI distinguishes between CLI actions and feedback actions.
+
+CLI actions are commands that `piquel` runs to inspect or change the user's
+workspace on their behalf. These commands must go through `CommandExecutor` so
+callers can swap execution behavior in tests or other embedding contexts.
+Examples include every `tmux` command and git commands used to list branches,
+list worktrees, or create a managed worktree.
+
+Feedback actions are interactions with the user at the current local prompt.
+They must stay local and must not go through `CommandExecutor`. Examples include
+printing project or session names with `println!`, printing top-level CLI errors
+with `eprintln!`, and running `fzf` so the user can make a selection.
+
+When adding code, use this rule:
+
+- If the command is part of accomplishing the requested operation, create a
+  `CommandRequest` in the owning module, usually `tmux` or `git`, and execute it
+  through `State::executor()`.
+- If the action exists to show information to the user or ask the user for a
+  choice, perform it directly in the local process or through the feedback
+  module, such as `fzf::select`.
+- Do not add stdout or stderr writing methods to `CommandExecutor`; user-visible
+  output is feedback, not command execution.
+
 ## Testing
 
 Run the whole test suite:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,13 @@
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
-use crate::{Config, config, tmux};
+use crate::{
+    Config, SessionConfig, WindowConfig, config,
+    executor::{CommandExecutor, LocalCommandExecutor},
+    tmux,
+};
 
 mod projects;
 mod sessions;
@@ -77,13 +81,21 @@ pub enum ProjectCommands {
 /// Runtime state shared by CLI command handlers.
 pub struct State {
     config: Config,
+    executor: Box<dyn CommandExecutor>,
 }
 
 impl State {
     /// Creates CLI state from loaded configuration.
     #[must_use]
     pub fn new(config: Config) -> Self {
-        Self { config }
+        Self {
+            config,
+            executor: Box::<LocalCommandExecutor>::default(),
+        }
+    }
+
+    pub(crate) fn executor(&self) -> &dyn CommandExecutor {
+        self.executor.as_ref()
     }
 
     /// Lists running tmux sessions.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,10 @@
 use clap::{Parser, Subcommand};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
 use crate::{
-    Config, SessionConfig, WindowConfig, config,
+    Config, config,
     executor::{CommandExecutor, LocalCommandExecutor},
     tmux,
 };
@@ -104,7 +104,14 @@ impl State {
     ///
     /// Returns an error if tmux session listing fails.
     pub fn list(&self) -> Result<()> {
-        tmux::list_sessions()?;
+        let mut sessions = tmux::list_sessions(self.executor())?;
+        sessions.sort();
+        sessions.dedup();
+
+        for session in sessions {
+            println!("{session}");
+        }
+
         Ok(())
     }
 }

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -103,7 +103,7 @@ impl State {
             return Ok(());
         }
 
-        let Some(branch) = self.select_fzf(branches, "branch> ")? else {
+        let Some(branch) = Self::select_fzf(branches, "branch> ")? else {
             return Ok(());
         };
 

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use anyhow::{Context, Result, anyhow, bail};
 
-use crate::{Config, ResolvedProject, SessionConfig, cli::State, fzf, git, tmux};
+use crate::{ResolvedProject, SessionConfig, cli::State, git, tmux};
 
 impl State {
     /// Lists configured projects.
@@ -60,8 +60,8 @@ impl State {
         validate_project_path(&project)?;
 
         match worktree {
-            Some(branch) => open_project_branch(&self.config, &project, template, branch)?,
-            None => tmux::open_session(&project.name, &project.path, template)?,
+            Some(branch) => self.open_project_branch(&project, template, branch)?,
+            None => tmux::open_session(self.executor(), &project.name, &project.path, template)?,
         }
 
         Ok(())
@@ -97,18 +97,88 @@ impl State {
 
         validate_project_path(&project)?;
 
-        let branches = git::list_local_branches(&project.path)?;
+        let branches = self.list_local_branches(&project.path)?;
         if branches.is_empty() {
-            tmux::open_session(&project.name, &project.path, template)?;
+            tmux::open_session(self.executor(), &project.name, &project.path, template)?;
             return Ok(());
         }
 
-        let Some(branch) = fzf::select(branches, "branch> ")? else {
+        let Some(branch) = self.select_fzf(branches, "branch> ")? else {
             return Ok(());
         };
 
-        open_project_branch(&self.config, &project, template, &branch)?;
+        self.open_project_branch(&project, template, &branch)?;
         Ok(())
+    }
+
+    fn open_project_branch(
+        &self,
+        project: &ResolvedProject,
+        template: &SessionConfig,
+        branch: &str,
+    ) -> Result<()> {
+        let branches = self.list_local_branches(&project.path)?;
+        if !branches.iter().any(|candidate| candidate == branch) {
+            bail!(
+                "Branch \"{}\" is not a local branch for project \"{}\"",
+                branch,
+                project.name
+            );
+        }
+
+        let worktrees = self.list_worktrees(&project.path)?;
+        let root = if let Some(worktree) = git::worktree_for_branch(&worktrees, branch) {
+            worktree.path
+        } else {
+            let worktree_path = git::managed_worktree_path_for_branch(
+                &self.config.worktrees_dir,
+                &project.name,
+                branch,
+                &worktrees,
+            )?;
+            if let Some(parent) = worktree_path.parent() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "Failed to create managed worktree directory {}",
+                        parent.display()
+                    )
+                })?;
+            }
+            self.create_worktree(&project.path, &worktree_path, branch)?;
+            worktree_path
+        };
+
+        let tmux_name = format!("{}--{branch}", project.name);
+        tmux::open_session(self.executor(), &tmux_name, &root, template)?;
+        Ok(())
+    }
+
+    fn list_local_branches(&self, project_path: &std::path::Path) -> Result<Vec<String>> {
+        let output = self
+            .executor()
+            .output(git::list_local_branches_request(project_path)?)?;
+        Ok(git::parse_local_branches_output(&output)?)
+    }
+
+    fn list_worktrees(&self, project_path: &std::path::Path) -> Result<Vec<git::Worktree>> {
+        let output = self
+            .executor()
+            .output(git::list_worktrees_request(project_path)?)?;
+        Ok(git::parse_worktrees_output(&output)?)
+    }
+
+    fn create_worktree(
+        &self,
+        project_path: &std::path::Path,
+        worktree_path: &std::path::Path,
+        branch: &str,
+    ) -> Result<()> {
+        let output = self.executor().output(git::create_worktree_request(
+            project_path,
+            worktree_path,
+            branch,
+        ))?;
+        Ok(git::parse_create_worktree_output(&output)?)
     }
 }
 
@@ -131,47 +201,5 @@ fn validate_project_path(project: &ResolvedProject) -> Result<()> {
         );
     }
 
-    Ok(())
-}
-
-fn open_project_branch(
-    config: &Config,
-    project: &ResolvedProject,
-    template: &SessionConfig,
-    branch: &str,
-) -> Result<()> {
-    let branches = git::list_local_branches(&project.path)?;
-    if !branches.iter().any(|candidate| candidate == branch) {
-        bail!(
-            "Branch \"{}\" is not a local branch for project \"{}\"",
-            branch,
-            project.name
-        );
-    }
-
-    let worktrees = git::list_worktrees(&project.path)?;
-    let root = if let Some(worktree) = git::worktree_for_branch(&worktrees, branch) {
-        worktree.path
-    } else {
-        let worktree_path = git::managed_worktree_path_for_branch(
-            &config.worktrees_dir,
-            &project.name,
-            branch,
-            &worktrees,
-        )?;
-        if let Some(parent) = worktree_path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!(
-                    "Failed to create managed worktree directory {}",
-                    parent.display()
-                )
-            })?;
-        }
-        git::create_worktree(&project.path, &worktree_path, branch)?;
-        worktree_path
-    };
-
-    let tmux_name = format!("{}--{branch}", project.name);
-    tmux::open_session(&tmux_name, &root, template)?;
     Ok(())
 }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -29,7 +29,7 @@ impl State {
         match self.pick_target()? {
             Some(PickTarget::TmuxSession(name)) => {
                 tmux::err_in_tmux()?;
-                tmux::attach(&name)?;
+                tmux::attach(self.executor(), &name)?;
             }
             Some(PickTarget::Project(name)) => {
                 self.open_project_interactive(&name, session_override)?;
@@ -85,7 +85,7 @@ impl State {
                 .into_owned(),
         };
 
-        tmux::open_session(&tmux_name, &root, template)?;
+        tmux::open_session(self.executor(), &tmux_name, &root, template)?;
         Ok(())
     }
 
@@ -95,10 +95,10 @@ impl State {
             .projects
             .iter()
             .filter_map(|project| project.resolved_name().ok());
-        let tmux_sessions = tmux::list_tmux_sessions()?;
+        let tmux_sessions = tmux::list_sessions(self.executor())?;
         let (items, mut targets) = build_pick_targets(tmux_sessions, project_names);
 
-        let Some(selection) = fzf::select(items, "piquel> ")? else {
+        let Some(selection) = self.select_fzf(items, "piquel> ")? else {
             return Ok(None);
         };
 
@@ -106,6 +106,13 @@ impl State {
             .remove(&selection)
             .map(Some)
             .ok_or_else(|| anyhow!("Selected unknown picker item \"{selection}\""))
+    }
+
+    pub(crate) fn select_fzf<I>(&self, items: I, prompt: &str) -> Result<Option<String>>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        Ok(fzf::select(items, prompt)?)
     }
 }
 

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -98,7 +98,7 @@ impl State {
         let tmux_sessions = tmux::list_sessions(self.executor())?;
         let (items, mut targets) = build_pick_targets(tmux_sessions, project_names);
 
-        let Some(selection) = self.select_fzf(items, "piquel> ")? else {
+        let Some(selection) = Self::select_fzf(items, "piquel> ")? else {
             return Ok(None);
         };
 
@@ -108,7 +108,7 @@ impl State {
             .ok_or_else(|| anyhow!("Selected unknown picker item \"{selection}\""))
     }
 
-    pub(crate) fn select_fzf<I>(&self, items: I, prompt: &str) -> Result<Option<String>>
+    pub(crate) fn select_fzf<I>(items: I, prompt: &str) -> Result<Option<String>>
     where
         I: IntoIterator<Item = String>,
     {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -9,8 +9,10 @@ use thiserror::Error;
 /// Standard input configuration for an executed command.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum CommandInput {
-    /// Inherit stdin from the current process.
+    /// Close stdin for the child process.
     #[default]
+    Closed,
+    /// Inherit stdin from the current process.
     Inherit,
     /// Pipe bytes into command stdin.
     Bytes(Vec<u8>),
@@ -209,6 +211,7 @@ impl CommandExecutor for LocalCommandExecutor {
 
 fn stdin_stdio(stdin: &CommandInput) -> Stdio {
     match stdin {
+        CommandInput::Closed => Stdio::null(),
         CommandInput::Inherit => Stdio::inherit(),
         CommandInput::Bytes(_) => Stdio::piped(),
     }
@@ -229,4 +232,17 @@ fn write_stdin(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_requests_close_stdin_by_default() {
+        assert_eq!(
+            CommandRequest::new("program").stdin_config(),
+            &CommandInput::Closed
+        );
+    }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,232 @@
+use std::{
+    ffi::{OsStr, OsString},
+    io::{self, Write},
+    process::{Command, ExitStatus, Stdio},
+};
+
+use thiserror::Error;
+
+/// Standard input configuration for an executed command.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum CommandInput {
+    /// Inherit stdin from the current process.
+    #[default]
+    Inherit,
+    /// Pipe bytes into command stdin.
+    Bytes(Vec<u8>),
+}
+
+/// Command execution request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandRequest {
+    program: OsString,
+    args: Vec<OsString>,
+    stdin: CommandInput,
+}
+
+impl CommandRequest {
+    /// Creates a request for `program`.
+    pub fn new(program: impl Into<OsString>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            stdin: CommandInput::default(),
+        }
+    }
+
+    /// Adds one argument.
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Adds many arguments.
+    #[must_use]
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// Configures stdin for this command.
+    #[must_use]
+    pub fn stdin(mut self, stdin: CommandInput) -> Self {
+        self.stdin = stdin;
+        self
+    }
+
+    fn program(&self) -> &OsStr {
+        &self.program
+    }
+
+    fn args_os(&self) -> impl Iterator<Item = &OsStr> {
+        self.args.iter().map(OsString::as_os_str)
+    }
+
+    fn stdin_config(&self) -> &CommandInput {
+        &self.stdin
+    }
+}
+
+impl From<CommandRequest> for Command {
+    fn from(value: CommandRequest) -> Self {
+        let mut command = Self::new(value.program());
+        command.args(value.args_os());
+        command
+    }
+}
+
+/// Commands to run sequentially.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CommandRequests {
+    requests: Vec<CommandRequest>,
+}
+
+impl CommandRequests {
+    /// Creates an empty command sequence.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a sequence containing one command.
+    #[must_use]
+    pub fn one(request: CommandRequest) -> Self {
+        Self {
+            requests: vec![request],
+        }
+    }
+
+    /// Appends a command to the sequence.
+    pub fn push(&mut self, request: CommandRequest) {
+        self.requests.push(request);
+    }
+
+    /// Appends many commands to the sequence.
+    pub fn extend(&mut self, requests: impl IntoIterator<Item = CommandRequest>) {
+        self.requests.extend(requests);
+    }
+}
+
+impl IntoIterator for CommandRequests {
+    type Item = CommandRequest;
+    type IntoIter = std::vec::IntoIter<CommandRequest>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.requests.into_iter()
+    }
+}
+
+/// Captured command result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutput {
+    /// Command exit status.
+    pub status: ExitStatus,
+    /// Captured stdout.
+    pub stdout: Vec<u8>,
+    /// Captured stderr.
+    pub stderr: Vec<u8>,
+}
+
+/// Errors produced by a command executor.
+#[derive(Debug, Error)]
+pub enum CommandExecutorError {
+    /// The command process could not be spawned or observed.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+}
+
+/// Runs commands requested by the CLI.
+pub trait CommandExecutor: Send + Sync {
+    /// Executes `request` and captures stdout and stderr.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command cannot be spawned or observed.
+    fn output(&self, request: CommandRequest) -> Result<CommandOutput, CommandExecutorError>;
+
+    /// Executes `request` while inheriting stdout and stderr.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command cannot be spawned or observed.
+    fn status(&self, request: CommandRequest) -> Result<ExitStatus, CommandExecutorError>;
+
+    /// Executes each request in order while inheriting stdout and stderr.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any command cannot be spawned or observed.
+    fn statuses(&self, requests: CommandRequests) -> Result<Vec<ExitStatus>, CommandExecutorError> {
+        requests
+            .into_iter()
+            .map(|request| self.status(request))
+            .collect()
+    }
+}
+
+/// Local process-backed command executor.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LocalCommandExecutor;
+
+impl CommandExecutor for LocalCommandExecutor {
+    fn output(&self, request: CommandRequest) -> Result<CommandOutput, CommandExecutorError> {
+        let stdin = request.stdin_config().clone();
+        let mut child = Command::from(request)
+            .stdin(stdin_stdio(&stdin))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        write_stdin(&mut child, &stdin)?;
+
+        let output = child.wait_with_output()?;
+
+        Ok(CommandOutput {
+            status: output.status,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+
+    fn status(&self, request: CommandRequest) -> Result<ExitStatus, CommandExecutorError> {
+        let stdin = request.stdin_config().clone();
+        let mut child = Command::from(request)
+            .stdin(stdin_stdio(&stdin))
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        write_stdin(&mut child, &stdin)?;
+
+        child.wait().map_err(CommandExecutorError::Io)
+    }
+}
+
+fn stdin_stdio(stdin: &CommandInput) -> Stdio {
+    match stdin {
+        CommandInput::Inherit => Stdio::inherit(),
+        CommandInput::Bytes(_) => Stdio::piped(),
+    }
+}
+
+fn write_stdin(
+    child: &mut std::process::Child,
+    stdin: &CommandInput,
+) -> Result<(), CommandExecutorError> {
+    if let CommandInput::Bytes(input) = stdin
+        && let Some(mut child_stdin) = child.stdin.take()
+    {
+        match child_stdin.write_all(input) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {}
+            Err(error) => return Err(CommandExecutorError::Io(error)),
+        }
+    }
+
+    Ok(())
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,9 +1,10 @@
 use std::{
     io,
     path::{Path, PathBuf},
-    process::Command,
 };
 use thiserror::Error;
+
+use crate::executor::{CommandExecutorError, CommandOutput, CommandRequest};
 
 /// A git worktree discovered from `git worktree list --porcelain`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,29 +51,37 @@ pub enum GitError {
     Parse(String),
 }
 
-/// Lists local branch names for `project_path`, sorted by git.
+impl From<CommandExecutorError> for GitError {
+    fn from(value: CommandExecutorError) -> Self {
+        match value {
+            CommandExecutorError::Io(err) => GitError::Io(err),
+        }
+    }
+}
+
+/// Returns the command request for listing local branch names.
 ///
 /// # Errors
 ///
-/// Returns an error if `project_path` does not exist or git fails.
-pub fn list_local_branches(project_path: &Path) -> Result<Vec<String>, GitError> {
+/// Returns an error if `project_path` does not exist.
+pub fn list_local_branches_request(project_path: &Path) -> Result<CommandRequest, GitError> {
     if !project_path.exists() {
         return Err(GitError::MissingProjectPath(project_path.to_owned()));
     }
 
-    let output = Command::new("git")
+    Ok(CommandRequest::new("git")
         .arg("-C")
-        .arg(project_path)
-        .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"])
-        .output()
-        .map_err(GitError::Io)?;
+        .arg(project_path.as_os_str())
+        .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"]))
+}
 
-    let combined = {
-        let mut s = String::from_utf8_lossy(&output.stdout).into_owned();
-        s.push_str(&String::from_utf8_lossy(&output.stderr));
-        s
-    };
-
+/// Parses local branch names from git output.
+///
+/// # Errors
+///
+/// Returns an error if git exited unsuccessfully.
+pub fn parse_local_branches_output(output: &CommandOutput) -> Result<Vec<String>, GitError> {
+    let combined = combined_output(output);
     if !output.status.success() {
         return Err(GitError::Command(combined));
     }
@@ -80,61 +89,57 @@ pub fn list_local_branches(project_path: &Path) -> Result<Vec<String>, GitError>
     Ok(parse_local_branches(&combined))
 }
 
-/// Creates a git worktree for `branch` at `worktree_path`.
-///
-/// # Errors
-///
-/// Returns an error if git fails.
-pub fn create_worktree(
+/// Returns the command request for creating a git worktree.
+#[must_use]
+pub fn create_worktree_request(
     project_path: &Path,
     worktree_path: &Path,
     branch: &str,
-) -> Result<(), GitError> {
-    let output = Command::new("git")
+) -> CommandRequest {
+    CommandRequest::new("git")
         .arg("-C")
-        .arg(project_path)
+        .arg(project_path.as_os_str())
         .args(["worktree", "add"])
-        .arg(worktree_path)
+        .arg(worktree_path.as_os_str())
         .arg(branch)
-        .output()
-        .map_err(GitError::Io)?;
+}
 
+/// Parses git worktree creation output.
+///
+/// # Errors
+///
+/// Returns an error if git exited unsuccessfully.
+pub fn parse_create_worktree_output(output: &CommandOutput) -> Result<(), GitError> {
     if output.status.success() {
         return Ok(());
     }
 
-    let combined = {
-        let mut s = String::from_utf8_lossy(&output.stdout).into_owned();
-        s.push_str(&String::from_utf8_lossy(&output.stderr));
-        s
-    };
-    Err(GitError::Command(combined))
+    Err(GitError::Command(combined_output(output)))
 }
 
-/// Lists all git worktrees for `project_path`.
+/// Returns the command request for listing all git worktrees.
 ///
 /// # Errors
 ///
-/// Returns an error if `project_path` does not exist, git fails, or the
-/// porcelain output cannot be parsed.
-pub fn list_worktrees(project_path: &Path) -> Result<Vec<Worktree>, GitError> {
+/// Returns an error if `project_path` does not exist.
+pub fn list_worktrees_request(project_path: &Path) -> Result<CommandRequest, GitError> {
     if !project_path.exists() {
         return Err(GitError::MissingProjectPath(project_path.to_owned()));
     }
 
-    let output = Command::new("git")
+    Ok(CommandRequest::new("git")
         .arg("-C")
-        .arg(project_path)
-        .args(["worktree", "list", "--porcelain"])
-        .output()
-        .map_err(GitError::Io)?;
+        .arg(project_path.as_os_str())
+        .args(["worktree", "list", "--porcelain"]))
+}
 
-    let combined = {
-        let mut s = String::from_utf8_lossy(&output.stdout).into_owned();
-        s.push_str(&String::from_utf8_lossy(&output.stderr));
-        s
-    };
-
+/// Parses git worktree list output.
+///
+/// # Errors
+///
+/// Returns an error if git exited unsuccessfully or output cannot be parsed.
+pub fn parse_worktrees_output(output: &CommandOutput) -> Result<Vec<Worktree>, GitError> {
+    let combined = combined_output(output);
     if !output.status.success() {
         return Err(GitError::Command(combined));
     }
@@ -142,13 +147,17 @@ pub fn list_worktrees(project_path: &Path) -> Result<Vec<Worktree>, GitError> {
     parse_worktrees(&combined)
 }
 
-/// Finds the worktree for `branch` under `project_path`.
+/// Finds the worktree for `branch` in an already-discovered worktree list.
 ///
 /// # Errors
 ///
-/// Returns an error if worktree listing fails or no worktree matches `branch`.
-pub fn find_worktree(project_path: &Path, branch: &str) -> Result<Worktree, GitError> {
-    find_worktree_in(list_worktrees(project_path)?, project_path, branch)
+/// Returns an error if no worktree matches `branch`.
+pub fn find_worktree(
+    worktrees: Vec<Worktree>,
+    project_path: &Path,
+    branch: &str,
+) -> Result<Worktree, GitError> {
+    find_worktree_in(worktrees, project_path, branch)
 }
 
 /// Finds the worktree for `branch` in an already-discovered worktree list.
@@ -209,6 +218,12 @@ fn parse_local_branches(input: &str) -> Vec<String> {
         .collect::<Vec<_>>();
     branches.sort();
     branches
+}
+
+fn combined_output(output: &CommandOutput) -> String {
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
 }
 
 fn push_worktree(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 pub mod cli;
 /// JSON config loading.
 pub mod config;
+/// Command execution and user output abstraction.
+pub mod executor;
 /// Interactive fuzzy selection helpers.
 pub mod fzf;
 /// Git worktree discovery helpers.

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,7 +1,12 @@
-use crate::{SessionConfig, WindowConfig};
+use crate::{
+    SessionConfig, WindowConfig,
+    executor::{
+        CommandExecutor, CommandExecutorError, CommandOutput, CommandRequest, CommandRequests,
+    },
+};
 use std::io;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::ExitStatus;
 use thiserror::Error;
 
 /// Errors produced while invoking tmux.
@@ -21,119 +26,204 @@ pub enum TmuxError {
     InvalidSessionName(String),
 }
 
-/// Lists running tmux sessions, sorted and deduplicated.
-/// Output is in stdout.
-///
-/// # Errors
-///
-/// Returns an error if tmux session listing fails.
-pub fn list_sessions() -> Result<(), TmuxError> {
-    let mut sessions = list_tmux_sessions()?;
-
-    sessions.sort();
-    sessions.dedup();
-
-    for session in &sessions {
-        println!("{session}");
+impl From<CommandExecutorError> for TmuxError {
+    fn from(value: CommandExecutorError) -> Self {
+        match value {
+            CommandExecutorError::Io(err) => TmuxError::Io(err),
+        }
     }
-
-    Ok(())
 }
 
-/// Returns the names of all running tmux sessions.
+/// Returns the command request for listing tmux sessions.
+#[must_use]
+pub fn list_sessions_request() -> CommandRequest {
+    tmux_request(["list-sessions", "-F", "#{session_name}"])
+}
+
+/// Lists running tmux sessions through `executor`.
 ///
 /// # Errors
 ///
-/// Returns an error if tmux fails for any reason other than having no running
-/// server.
-pub fn list_tmux_sessions() -> Result<Vec<String>, TmuxError> {
-    match exec_tmux_return(&["list-sessions", "-F", "#{session_name}"]) {
-        Ok(output) => {
-            let trimmed = output.trim_matches('\n');
-            if trimmed.is_empty() {
-                return Ok(vec![]);
-            }
-            Ok(trimmed.split('\n').map(str::to_owned).collect())
-        }
-        Err(TmuxError::Command(ref msg))
-            if msg.starts_with("no server running on")
-                || msg.starts_with("error connecting to") =>
+/// Returns an error if tmux cannot be invoked or returns an unexpected failure.
+pub fn list_sessions(executor: &dyn CommandExecutor) -> Result<Vec<String>, TmuxError> {
+    let output = executor.output(list_sessions_request())?;
+    parse_list_sessions_output(&output)
+}
+
+/// Parses tmux session names from `list-sessions` output.
+///
+/// # Errors
+///
+/// Returns an error if tmux failed for a reason other than a missing server.
+pub fn parse_list_sessions_output(output: &CommandOutput) -> Result<Vec<String>, TmuxError> {
+    let combined = combined_output(output);
+
+    if !output.status.success() {
+        if combined.starts_with("no server running on")
+            || combined.starts_with("error connecting to")
         {
-            Ok(vec![])
+            return Ok(vec![]);
         }
-        Err(_) => {
-            let raw =
-                exec_tmux_return(&["list-sessions", "-F", "#{session_name}"]).unwrap_or_default();
-            Err(TmuxError::Command(format!(
-                "Failed to list sessions with error: {raw}"
-            )))
-        }
+
+        return Err(TmuxError::Command(format!(
+            "Failed to list sessions with error: {combined}"
+        )));
     }
+
+    let trimmed = combined.trim_matches('\n');
+    if trimmed.is_empty() {
+        return Ok(vec![]);
+    }
+
+    Ok(trimmed.split('\n').map(str::to_owned).collect())
 }
 
-/// Attaches to a running tmux session and returns its combined output.
+/// Returns the command request for attaching to a tmux session.
+#[must_use]
+pub fn attach_request(session: &str) -> CommandRequest {
+    tmux_request(["attach", "-t", session])
+}
+
+/// Attaches to an existing tmux session through `executor`.
 ///
 /// # Errors
 ///
 /// Returns an error if tmux cannot attach to the requested session.
-pub fn attach(session: &str) -> Result<String, TmuxError> {
-    exec_tmux_return(&["attach", "-t", session])
+pub fn attach(executor: &dyn CommandExecutor, name: &str) -> Result<String, TmuxError> {
+    let output = executor.output(attach_request(name))?;
+    successful_output(&output)
 }
 
-/// Opens a tmux session for `root` using `template`, creating it when needed.
+/// Returns the command request for creating a detached tmux session.
+#[must_use]
+pub fn new_session_request(tmux_name: &str, root: &Path) -> CommandRequest {
+    tmux_request([
+        "new-session",
+        "-d",
+        "-c",
+        &root.to_string_lossy(),
+        "-s",
+        tmux_name,
+    ])
+}
+
+/// Returns the command request for listing tmux windows.
+#[must_use]
+pub fn list_windows_request(tmux_name: &str) -> CommandRequest {
+    tmux_request(["list-windows", "-t", tmux_name, "-F", "#{window_id}"])
+}
+
+/// Returns the command request for creating a tmux window.
+#[must_use]
+pub fn new_window_request(
+    session_name: &str,
+    start_dir: &Path,
+    window: &WindowConfig,
+) -> CommandRequest {
+    let mut request = tmux_request(["new-window", "-P", "-F", "#{window_id}"]);
+
+    if let Some(name) = &window.name {
+        request = request.args(["-n", name]);
+    }
+
+    request.args([
+        "-t",
+        session_name,
+        "-c",
+        start_dir.to_string_lossy().as_ref(),
+    ])
+}
+
+/// Returns the command request for sending keys to a tmux window.
+#[must_use]
+pub fn send_keys_request(window_id: &str, command: &str) -> CommandRequest {
+    tmux_request(["send-keys", "-t", window_id, command, "Enter"])
+}
+
+/// Returns command requests for all configured commands in a tmux window.
+#[must_use]
+pub fn send_keys_requests(window_id: &str, window: &WindowConfig) -> CommandRequests {
+    let mut requests = CommandRequests::new();
+    requests.extend(
+        window
+            .commands
+            .iter()
+            .map(|command| send_keys_request(window_id, command)),
+    );
+    requests
+}
+
+/// Returns the command request for killing a tmux window.
+#[must_use]
+pub fn kill_window_request(window_id: &str) -> CommandRequest {
+    tmux_request(["kill-window", "-t", window_id])
+}
+
+/// Returns the command request for selecting a tmux window.
+#[must_use]
+pub fn select_window_request(window_id: &str) -> CommandRequest {
+    tmux_request(["select-window", "-t", window_id])
+}
+
+/// Opens a tmux session from `template`, creating it first when necessary.
 ///
 /// # Errors
 ///
-/// Returns an error if the session name is invalid, tmux cannot create or
-/// configure the session, or attaching fails.
+/// Returns an error if the session name is invalid or any tmux command fails.
 pub fn open_session(
+    executor: &dyn CommandExecutor,
     tmux_name: &str,
     root: &Path,
     template: &SessionConfig,
 ) -> Result<(), TmuxError> {
     let tmux_name = validated_session_name(tmux_name)?;
 
-    let sessions = list_tmux_sessions()?;
+    let sessions = list_sessions(executor)?;
     if sessions.contains(&tmux_name) {
-        attach(&tmux_name)?;
+        attach(executor, &tmux_name)?;
         return Ok(());
     }
 
-    exec_tmux(&[
-        "new-session",
-        "-d",
-        "-c",
-        &root.to_string_lossy(),
-        "-s",
-        &tmux_name,
-    ])
-    .map_err(|_| TmuxError::Command(format!("Failed to create session with name {tmux_name}")))?;
+    let status = executor
+        .status(new_session_request(&tmux_name, root))
+        .map_err(|_| {
+            TmuxError::Command(format!("Failed to create session with name {tmux_name}"))
+        })?;
+    successful_status(status).map_err(|_| {
+        TmuxError::Command(format!("Failed to create session with name {tmux_name}"))
+    })?;
 
-    let bootstrap_window =
-        exec_tmux_return(&["list-windows", "-t", &tmux_name, "-F", "#{window_id}"]).map_err(
-            |e| TmuxError::Command(format!("Failed to list tmux windows with error: {e}")),
-        )?;
-
+    let output = executor
+        .output(list_windows_request(&tmux_name))
+        .map_err(|e| TmuxError::Command(format!("Failed to list tmux windows with error: {e}")))?;
+    let bootstrap_window = successful_output(&output)
+        .map_err(|e| TmuxError::Command(format!("Failed to list tmux windows with error: {e}")))?;
     let bootstrap_window = bootstrap_window.trim_matches('\n').to_owned();
     let mut first_window = None;
 
     for (i, window) in template.windows.iter().enumerate() {
-        let window_id = new_window(&tmux_name, root, window).map_err(|e| {
+        let window_id = create_window(executor, &tmux_name, root, window).map_err(|e| {
             TmuxError::Command(format!("Failed to create window {} with error: {e}", i + 1))
         })?;
 
         first_window.get_or_insert(window_id);
     }
 
-    exec_tmux(&["kill-window", "-t", &bootstrap_window])
+    let status = executor
+        .status(kill_window_request(&bootstrap_window))
+        .map_err(|_| TmuxError::Command("Failed to kill first window".to_owned()))?;
+    successful_status(status)
         .map_err(|_| TmuxError::Command("Failed to kill first window".to_owned()))?;
 
     if let Some(first_window) = first_window {
-        exec_tmux(&["select-window", "-t", &first_window])
+        let status = executor
+            .status(select_window_request(&first_window))
+            .map_err(|_| TmuxError::Command("Failed to select first window".to_owned()))?;
+        successful_status(status)
             .map_err(|_| TmuxError::Command("Failed to select first window".to_owned()))?;
     }
 
-    attach(&tmux_name).map_err(|_| {
+    attach(executor, &tmux_name).map_err(|_| {
         TmuxError::Command(format!(
             "Failed to attach to session with error: {tmux_name}"
         ))
@@ -142,40 +232,46 @@ pub fn open_session(
     Ok(())
 }
 
-/// Creates a new tmux window rooted at `start_dir` and sends its commands.
+/// Converts successful command output into combined stdout and stderr text.
 ///
 /// # Errors
 ///
-/// Returns an error if tmux cannot create the window or send one of the
-/// configured commands.
-pub fn new_window(
-    session_name: &str,
-    start_dir: &Path,
-    window: &WindowConfig,
-) -> Result<String, TmuxError> {
-    let start_dir = start_dir.to_string_lossy();
-    let mut args = vec!["new-window", "-P", "-F", "#{window_id}"];
+/// Returns an error if the command status was unsuccessful.
+pub fn successful_output(output: &CommandOutput) -> Result<String, TmuxError> {
+    let combined = combined_output(output);
+    if output.status.success() {
+        Ok(combined)
+    } else {
+        Err(TmuxError::Command(combined))
+    }
+}
 
-    if let Some(name) = &window.name {
-        args.extend(["-n", name]);
+/// Converts a command exit status into a tmux result.
+///
+/// # Errors
+///
+/// Returns an error if the command status was unsuccessful.
+pub fn successful_status(status: ExitStatus) -> Result<(), TmuxError> {
+    if status.success() {
+        Ok(())
+    } else {
+        Err(TmuxError::Command(format!(
+            "tmux exited with status {status}"
+        )))
+    }
+}
+
+/// Converts multiple command exit statuses into a tmux result.
+///
+/// # Errors
+///
+/// Returns an error if any command status was unsuccessful.
+pub fn successful_statuses(statuses: Vec<ExitStatus>) -> Result<(), TmuxError> {
+    for status in statuses {
+        successful_status(status)?;
     }
 
-    args.extend(["-t", session_name, "-c", &start_dir]);
-
-    let window_id = exec_tmux_return(&args)
-        .map_err(|e| TmuxError::Command(format!("Failed to create window with error: {e}")))?;
-
-    let window_id = window_id.trim_matches('\n').to_owned();
-
-    for command in &window.commands {
-        exec_tmux_return(&["send-keys", "-t", &window_id, command, "Enter"]).map_err(|e| {
-            TmuxError::Command(format!(
-                "Failed to execute command \"{command}\" with error: {e}"
-            ))
-        })?;
-    }
-
-    Ok(window_id)
+    Ok(())
 }
 
 /// Returns an error when the current process is already running inside tmux.
@@ -244,41 +340,45 @@ pub fn validated_session_name(input: &str) -> Result<String, TmuxError> {
     Ok(sanitized)
 }
 
-fn exec_tmux(args: &[&str]) -> Result<(), TmuxError> {
-    Command::new("tmux")
-        .args(args)
-        .stdin(Stdio::inherit())
-        .status()
-        .map_err(TmuxError::Io)
-        .and_then(|status| {
-            if status.success() {
-                Ok(())
-            } else {
-                Err(TmuxError::Command(format!(
-                    "tmux exited with status {status}"
-                )))
-            }
-        })
+fn tmux_request<'a>(args: impl IntoIterator<Item = &'a str>) -> CommandRequest {
+    CommandRequest::new("tmux").args(args)
 }
 
-fn exec_tmux_return(args: &[&str]) -> Result<String, TmuxError> {
-    let output = Command::new("tmux")
-        .args(args)
-        .stdin(Stdio::inherit())
-        .output()
-        .map_err(TmuxError::Io)?;
+fn create_window(
+    executor: &dyn CommandExecutor,
+    session_name: &str,
+    start_dir: &Path,
+    window: &WindowConfig,
+) -> Result<String, TmuxError> {
+    let output = executor
+        .output(new_window_request(session_name, start_dir, window))
+        .map_err(|e| TmuxError::Command(format!("Failed to create window with error: {e}")))?;
+    let window_id = successful_output(&output)
+        .map_err(|e| TmuxError::Command(format!("Failed to create window with error: {e}")))?;
+    let window_id = window_id.trim_matches('\n').to_owned();
 
-    let combined = {
-        let mut s = String::from_utf8_lossy(&output.stdout).into_owned();
-        s.push_str(&String::from_utf8_lossy(&output.stderr));
-        s
-    };
-
-    if output.status.success() {
-        Ok(combined)
-    } else {
-        Err(TmuxError::Command(combined))
+    for command in &window.commands {
+        let output = executor
+            .output(send_keys_request(&window_id, command))
+            .map_err(|e| {
+                TmuxError::Command(format!(
+                    "Failed to execute command \"{command}\" with error: {e}"
+                ))
+            })?;
+        successful_output(&output).map_err(|e| {
+            TmuxError::Command(format!(
+                "Failed to execute command \"{command}\" with error: {e}"
+            ))
+        })?;
     }
+
+    Ok(window_id)
+}
+
+fn combined_output(output: &CommandOutput) -> String {
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
 }
 
 #[cfg(test)]

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,7 +1,8 @@
 use crate::{
     SessionConfig, WindowConfig,
     executor::{
-        CommandExecutor, CommandExecutorError, CommandOutput, CommandRequest, CommandRequests,
+        CommandExecutor, CommandExecutorError, CommandInput, CommandOutput, CommandRequest,
+        CommandRequests,
     },
 };
 use std::io;
@@ -341,7 +342,9 @@ pub fn validated_session_name(input: &str) -> Result<String, TmuxError> {
 }
 
 fn tmux_request<'a>(args: impl IntoIterator<Item = &'a str>) -> CommandRequest {
-    CommandRequest::new("tmux").args(args)
+    CommandRequest::new("tmux")
+        .args(args)
+        .stdin(CommandInput::Inherit)
 }
 
 fn create_window(


### PR DESCRIPTION
## Summary
- Introduce a `CommandExecutor` abstraction and route CLI, git, and tmux command execution through request builders.
- Move tmux and git helpers toward parse/request separation so command behavior can be swapped in tests or embedded contexts.
- Update CLI project/session flows to use the executor-backed APIs and local feedback paths consistently.
- Document the command execution model in `README.md`.