### PR TITLE
fix: resolve `session .` to the current directory

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,6 +154,6 @@ pub fn run() -> Result<()> {
             path,
             session,
             name,
-        } => state.session(path.clone(), session.as_deref(), name.as_deref()),
+        } => state.session(path.as_deref(), session.as_deref(), name.as_deref()),
     }
 }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -61,10 +61,7 @@ impl State {
             .session_template(template_name)
             .ok_or_else(|| anyhow!("Session template \"{template_name}\" is not configured"))?;
 
-        let root = match path {
-            Some(path) => expand_home(&path),
-            None => std::env::current_dir().context("Failed to determine current directory")?,
-        };
+        let root = resolve_session_root(path.as_deref())?;
 
         if !root.exists() {
             bail!("Session path {} does not exist", root.display());
@@ -123,6 +120,16 @@ fn expand_home(path: &Path) -> PathBuf {
         return home.join(stripped);
     }
     path.to_path_buf()
+}
+
+fn resolve_session_root(path: Option<&Path>) -> Result<PathBuf> {
+    match path {
+        Some(path) if path == Path::new(".") => {
+            std::env::current_dir().context("Failed to determine current directory")
+        }
+        Some(path) => Ok(expand_home(path)),
+        None => std::env::current_dir().context("Failed to determine current directory"),
+    }
 }
 
 fn build_pick_targets<T, P>(

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -49,7 +49,7 @@ impl State {
     /// or tmux cannot open the session.
     pub fn session(
         &self,
-        path: Option<PathBuf>,
+        path: Option<&Path>,
         session_override: Option<&str>,
         name_override: Option<&str>,
     ) -> Result<()> {
@@ -61,7 +61,7 @@ impl State {
             .session_template(template_name)
             .ok_or_else(|| anyhow!("Session template \"{template_name}\" is not configured"))?;
 
-        let root = resolve_session_root(path.as_deref())?;
+        let root = resolve_session_root(path)?;
 
         if !root.exists() {
             bail!("Session path {} does not exist", root.display());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -558,6 +558,45 @@ fn project_load_creates_tmux_session_from_configured_template() {
 }
 
 #[test]
+fn session_dot_path_uses_current_directory_name() {
+    let temp = TestDir::new();
+    let session_path = temp.path().join("workspaces/alpha");
+    fs::create_dir_all(&session_path).expect("session path should be created");
+    let tmux_log = temp.path().join("tmux.log");
+    let config = write_config(
+        &temp,
+        r#"{
+            "default_session": "default",
+            "sessions": {
+                "default": { "windows": [{ "commands": ["vim ."] }] }
+            }
+        }"#,
+    );
+    let bin = bin_dir_with(&temp, &[("tmux", fake_tmux_script(&tmux_log, ""))]);
+
+    let output = piquel()
+        .current_dir(&session_path)
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "session", "."])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let resolved_session_path = session_path
+        .canonicalize()
+        .expect("session path should resolve");
+    let log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(log.contains(&format!(
+        "new-session -d -c {} -s alpha",
+        path_str(&resolved_session_path)
+    )));
+    assert!(log.contains("send-keys -t window-id vim . Enter"));
+    assert!(log.contains("attach -t alpha"));
+}
+
+#[test]
 fn project_load_names_configured_tmux_windows() {
     let temp = TestDir::new();
     let project_path = temp.path().join("projects/alpha");


### PR DESCRIPTION
## Summary
- Treat `session .` as the current working directory instead of a literal relative path.
- Keep existing home expansion behavior for other explicit paths.
- Add an integration test that verifies `session .` starts a tmux session rooted at the current directory and runs the configured commands.