### PR TITLE
feat: clone missing projects before opening sessions

### DIFF
--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -1,4 +1,7 @@
-use std::fs;
+use std::{
+    fs,
+    io::{self, Write},
+};
 
 use anyhow::{Context, Result, anyhow, bail};
 
@@ -57,7 +60,7 @@ impl State {
                 anyhow!("Session template \"{template_name}\" is not configured")
             })?;
 
-        validate_project_path(&project)?;
+        self.ensure_project_path(&project)?;
 
         match worktree {
             Some(branch) => self.open_project_branch(&project, template, branch)?,
@@ -95,7 +98,7 @@ impl State {
                 anyhow!("Session template \"{template_name}\" is not configured")
             })?;
 
-        validate_project_path(&project)?;
+        self.ensure_project_path(&project)?;
 
         let branches = self.list_local_branches(&project.path)?;
         if branches.is_empty() {
@@ -180,24 +183,73 @@ impl State {
         ))?;
         Ok(git::parse_create_worktree_output(&output)?)
     }
+
+    fn ensure_project_path(&self, project: &ResolvedProject) -> Result<()> {
+        if project.path.exists() {
+            if !project.path.is_dir() {
+                bail!(
+                    "Project \"{}\" path {} is not a directory",
+                    project.name,
+                    project.path.display(),
+                );
+            }
+            return Ok(());
+        }
+
+        if !prompt_clone_project(project)? {
+            bail!(
+                "Project \"{}\" path {} does not exist; clone cancelled",
+                project.name,
+                project.path.display()
+            );
+        }
+
+        clone_project(self.executor(), project)
+    }
 }
 
-fn validate_project_path(project: &ResolvedProject) -> Result<()> {
-    if !project.path.exists() {
-        bail!(
-            "Project \"{}\" path {} does not exist; configured repository is {}",
-            project.name,
-            project.path.display(),
-            project.repository
-        );
+fn prompt_clone_project(project: &ResolvedProject) -> Result<bool> {
+    eprint!(
+        "Project \"{}\" path {} does not exist. Clone {} there? [y/N] ",
+        project.name,
+        project.path.display(),
+        project.repository
+    );
+    io::stderr().flush().context("Failed to flush stderr")?;
+
+    let mut answer = String::new();
+    io::stdin()
+        .read_line(&mut answer)
+        .context("Failed to read clone confirmation")?;
+
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn clone_project(
+    executor: &dyn crate::executor::CommandExecutor,
+    project: &ResolvedProject,
+) -> Result<()> {
+    if let Some(parent) = project.path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create project parent directory {}",
+                parent.display()
+            )
+        })?;
     }
 
-    if !project.path.is_dir() {
+    let status = executor.status(git::clone_repository_request(
+        &project.repository,
+        &project.path,
+    ))?;
+    if !status.success() {
         bail!(
-            "Project \"{}\" path {} is not a directory; configured repository is {}",
-            project.name,
-            project.path.display(),
-            project.repository
+            "Failed to clone repository {} into {}",
+            project.repository,
+            project.path.display()
         );
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -104,6 +104,14 @@ pub fn create_worktree_request(
         .arg(branch)
 }
 
+/// Returns the command request for cloning a repository into `project_path`.
+#[must_use]
+pub fn clone_repository_request(repository: &str, project_path: &Path) -> CommandRequest {
+    CommandRequest::new("git")
+        .args(["clone", repository])
+        .arg(project_path.as_os_str())
+}
+
 /// Parses git worktree creation output.
 ///
 /// # Errors

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -260,6 +260,23 @@ branch refs/heads/feature/foo
     )
 }
 
+fn fake_git_clone_script(log: &Path) -> String {
+    format!(
+        r#"#!{}
+log={}
+if [ "$1" = "clone" ]; then
+    printf '%s\n' "$*" >> "$log"
+    mkdir -p "$3"
+    exit 0
+fi
+
+exit 64
+"#,
+        path_str(&shell_path()),
+        shell_quote(path_str(log))
+    )
+}
+
 fn assert_success(output: &Output, stdout: &str, stderr: &str) {
     assert!(
         output.status.success(),
@@ -445,7 +462,7 @@ fn unsafe_project_name_exits_with_validation_error() {
 }
 
 #[test]
-fn project_load_rejects_missing_project_path_before_opening_tmux_session() {
+fn project_load_declining_missing_project_clone_does_not_open_tmux_session() {
     let temp = TestDir::new();
     let config = write_config(
         &temp,
@@ -462,14 +479,101 @@ fn project_load_rejects_missing_project_path_before_opening_tmux_session() {
             ]
         }"#,
     );
+    let tmux_log = temp.path().join("tmux.log");
+    let bin = bin_dir_with(&temp, &[("tmux", fake_tmux_script(&tmux_log, ""))]);
 
-    let output = piquel()
+    let mut child = piquel()
         .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
         .args(["--config", path_str(&config), "project", "load", "alpha"])
-        .output()
-        .expect("piquel should run");
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("piquel should spawn");
+    std::io::Write::write_all(child.stdin.as_mut().expect("stdin should be piped"), b"n\n")
+        .expect("stdin should be writable");
+    let output = child
+        .wait_with_output()
+        .expect("piquel output should be readable");
 
-    assert_failure(&output, &["Project \"alpha\" path", "does not exist"]);
+    assert_failure(&output, &["Clone", "cancelled"]);
+    assert!(!tmux_log.exists(), "tmux should not be opened");
+}
+
+#[test]
+fn project_load_clones_missing_project_then_opens_tmux_session() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("projects/alpha");
+    let tmux_log = temp.path().join("tmux.log");
+    let git_log = temp.path().join("git.log");
+    let config = write_config(
+        &temp,
+        &format!(
+            r#"{{
+                "default_session": "default",
+                "sessions": {{
+                    "default": {{ "windows": [{{ "commands": [] }}] }}
+                }},
+                "projects": [
+                    {{
+                        "repository": "https://github.com/owner/alpha.git",
+                        "path": {}
+                    }}
+                ]
+            }}"#,
+            serde_json::to_string(path_str(&project_path)).expect("path should serialize")
+        ),
+    );
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "")),
+            ("git", fake_git_clone_script(&git_log)),
+        ],
+    );
+
+    let mut child = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "project", "load", "alpha"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("piquel should spawn");
+    std::io::Write::write_all(
+        child.stdin.as_mut().expect("stdin should be piped"),
+        b"yes\n",
+    )
+    .expect("stdin should be writable");
+    let output = child
+        .wait_with_output()
+        .expect("piquel output should be readable");
+
+    assert_success(
+        &output,
+        "",
+        &format!(
+            "Project \"alpha\" path {} does not exist. Clone https://github.com/owner/alpha.git there? [y/N] ",
+            project_path.display()
+        ),
+    );
+
+    let git_log = fs::read_to_string(git_log).expect("git log should be readable");
+    assert_eq!(
+        git_log,
+        format!(
+            "clone https://github.com/owner/alpha.git {}\n",
+            path_str(&project_path)
+        )
+    );
+
+    let tmux_log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(tmux_log.contains(&format!(
+        "new-session -d -c {} -s alpha",
+        path_str(&project_path)
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Prompt before cloning a missing project path instead of failing immediately.
- Add `git clone` request plumbing and create parent directories before cloning.
- Keep project loads from opening tmux when the user declines the clone.
- Extend CLI tests to cover declined clone and successful clone-then-open flows.