### PR TITLE
refactor: command execution into backend abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,19 @@ contain `/`, `\`, or `:`. Session names must not be empty or contain `:`. tmux
 session names derived from worktree branches are sanitized before tmux is
 invoked. Window names, when set, must not be blank.
 
-## Command Execution Model
+## Backend Model
 
 The CLI distinguishes between CLI actions and feedback actions.
 
-CLI actions are commands that `piquel` runs to inspect or change the user's
-workspace on their behalf. These commands must go through `CommandExecutor` so
-callers can swap execution behavior in tests or other embedding contexts.
-Examples include every `tmux` command and git commands used to list branches,
-list worktrees, or create a managed worktree.
+CLI actions inspect or change the user's workspace on their behalf. These
+actions must go through `Backend` so callers can swap local or remote execution
+behavior in tests or other embedding contexts. Examples include every `tmux`
+command, git commands used to list branches, list worktrees, clone projects, or
+create a managed worktree, `~` expansion, path existence and directory checks,
+directory creation, and program validation.
 
 Feedback actions are interactions with the user at the current local prompt.
-They must stay local and must not go through `CommandExecutor`. Examples include
+They must stay local and must not go through `Backend`. Examples include
 printing project or session names with `println!`, printing top-level CLI errors
 with `eprintln!`, and running `fzf` so the user can make a selection.
 
@@ -196,11 +197,13 @@ When adding code, use this rule:
 - If the command is part of accomplishing the requested operation, create a
   `CommandRequest` in the owning module, usually `tmux` or `git`. Higher-level
   wrappers that need to run several commands should stay in that owning module
-  and take `&dyn CommandExecutor` as a parameter.
+  and take `&dyn Backend` as a parameter.
+- If code needs the backend home directory, current directory, path metadata,
+  directory creation, canonical paths, or program availability, ask `Backend`.
 - If the action exists to show information to the user or ask the user for a
   choice, perform it directly in the local process or through the feedback
   module, such as `fzf::select`.
-- Do not add stdout or stderr writing methods to `CommandExecutor`; user-visible
+- Do not add stdout or stderr writing methods to `Backend`; user-visible
   output is feedback, not command execution.
 
 ## Testing

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,10 +1,14 @@
 use std::{
     ffi::{OsStr, OsString},
-    io::{self, Write},
+    io,
+    path::{Path, PathBuf},
     process::{Command, ExitStatus, Stdio},
 };
 
 use thiserror::Error;
+
+mod local;
+pub use local::LocalBackend;
 
 /// Standard input configuration for an executed command.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -16,6 +20,16 @@ pub enum CommandInput {
     Inherit,
     /// Pipe bytes into command stdin.
     Bytes(Vec<u8>),
+}
+
+impl From<CommandInput> for Stdio {
+    fn from(value: CommandInput) -> Self {
+        match value {
+            CommandInput::Closed => Self::null(),
+            CommandInput::Inherit => Self::inherit(),
+            CommandInput::Bytes(_) => Self::piped(),
+        }
+    }
 }
 
 /// Command execution request.
@@ -134,104 +148,121 @@ pub struct CommandOutput {
     pub stderr: Vec<u8>,
 }
 
-/// Errors produced by a command executor.
+/// Errors produced by a backend.
 #[derive(Debug, Error)]
-pub enum CommandExecutorError {
+pub enum BackendError {
     /// The command process could not be spawned or observed.
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
+    /// The backend could not determine a home directory.
+    #[error("home directory not found")]
+    HomeDirNotFound,
+    /// The requested program is not available to this backend.
+    #[error("{0} is not installed or not available in PATH")]
+    MissingProgram(String),
 }
 
-/// Runs commands requested by the CLI.
-pub trait CommandExecutor: Send + Sync {
+/// Performs machine interactions requested by the CLI.
+pub trait Backend: Send + Sync {
     /// Executes `request` and captures stdout and stderr.
     ///
     /// # Errors
     ///
     /// Returns an error if the command cannot be spawned or observed.
-    fn output(&self, request: CommandRequest) -> Result<CommandOutput, CommandExecutorError>;
+    fn output(&self, request: CommandRequest) -> Result<CommandOutput, BackendError>;
 
     /// Executes `request` while inheriting stdout and stderr.
     ///
     /// # Errors
     ///
     /// Returns an error if the command cannot be spawned or observed.
-    fn status(&self, request: CommandRequest) -> Result<ExitStatus, CommandExecutorError>;
+    fn status(&self, request: CommandRequest) -> Result<ExitStatus, BackendError>;
 
     /// Executes each request in order while inheriting stdout and stderr.
     ///
     /// # Errors
     ///
     /// Returns an error if any command cannot be spawned or observed.
-    fn statuses(&self, requests: CommandRequests) -> Result<Vec<ExitStatus>, CommandExecutorError> {
+    fn statuses(&self, requests: CommandRequests) -> Result<Vec<ExitStatus>, BackendError> {
         requests
             .into_iter()
             .map(|request| self.status(request))
             .collect()
     }
-}
 
-/// Local process-backed command executor.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct LocalCommandExecutor;
+    /// Returns the backend user's home directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend cannot determine a home directory.
+    fn home_dir(&self) -> Result<PathBuf, BackendError>;
 
-impl CommandExecutor for LocalCommandExecutor {
-    fn output(&self, request: CommandRequest) -> Result<CommandOutput, CommandExecutorError> {
-        let stdin = request.stdin_config().clone();
-        let mut child = Command::from(request)
-            .stdin(stdin_stdio(&stdin))
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
+    /// Returns the backend's current directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the current directory cannot be determined.
+    fn current_dir(&self) -> Result<PathBuf, BackendError>;
 
-        write_stdin(&mut child, &stdin)?;
-
-        let output = child.wait_with_output()?;
-
-        Ok(CommandOutput {
-            status: output.status,
-            stdout: output.stdout,
-            stderr: output.stderr,
-        })
-    }
-
-    fn status(&self, request: CommandRequest) -> Result<ExitStatus, CommandExecutorError> {
-        let stdin = request.stdin_config().clone();
-        let mut child = Command::from(request)
-            .stdin(stdin_stdio(&stdin))
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .spawn()?;
-
-        write_stdin(&mut child, &stdin)?;
-
-        child.wait().map_err(CommandExecutorError::Io)
-    }
-}
-
-fn stdin_stdio(stdin: &CommandInput) -> Stdio {
-    match stdin {
-        CommandInput::Closed => Stdio::null(),
-        CommandInput::Inherit => Stdio::inherit(),
-        CommandInput::Bytes(_) => Stdio::piped(),
-    }
-}
-
-fn write_stdin(
-    child: &mut std::process::Child,
-    stdin: &CommandInput,
-) -> Result<(), CommandExecutorError> {
-    if let CommandInput::Bytes(input) = stdin
-        && let Some(mut child_stdin) = child.stdin.take()
-    {
-        match child_stdin.write_all(input) {
-            Ok(()) => {}
-            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {}
-            Err(error) => return Err(CommandExecutorError::Io(error)),
+    /// Expands a leading `~` using the backend user's home directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if expansion requires a home directory and none is
+    /// available.
+    fn expand_home(&self, path: &Path) -> Result<PathBuf, BackendError> {
+        if let Ok(stripped) = path.strip_prefix("~") {
+            return Ok(self.home_dir()?.join(stripped));
         }
+
+        Ok(path.to_path_buf())
     }
 
-    Ok(())
+    /// Returns whether `path` exists on the backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend cannot query the path.
+    fn path_exists(&self, path: &Path) -> Result<bool, BackendError>;
+
+    /// Returns whether `path` is a directory on the backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend cannot query the path.
+    fn path_is_dir(&self, path: &Path) -> Result<bool, BackendError>;
+
+    /// Creates `path` and any missing parent directories on the backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be created.
+    fn create_dir_all(&self, path: &Path) -> Result<(), BackendError>;
+
+    /// Canonicalizes `path` on the backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path cannot be canonicalized.
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, BackendError>;
+
+    /// Validates that `program` is available to this backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the program cannot be found.
+    fn validate_program(&self, program: &OsStr) -> Result<(), BackendError>;
+}
+
+#[cfg(test)]
+fn shell() -> OsString {
+    std::env::var_os("PATH")
+        .into_iter()
+        .flat_map(|paths| std::env::split_paths(&paths).collect::<Vec<_>>())
+        .flat_map(|path| [path.join("sh"), path.join("bash")])
+        .find(|path| path.exists())
+        .expect("test shell should be available in PATH")
+        .into_os_string()
 }
 
 #[cfg(test)]
@@ -281,8 +312,8 @@ mod tests {
 
     #[test]
     fn default_statuses_runs_requests_in_order() {
-        let executor = RecordingExecutor::default();
-        let statuses = executor
+        let backend = RecordingBackend::default();
+        let statuses = backend
             .statuses({
                 let mut requests = CommandRequests::new();
                 requests.push(CommandRequest::new("first"));
@@ -294,41 +325,17 @@ mod tests {
         assert_eq!(statuses.len(), 2);
         assert!(statuses.iter().all(ExitStatus::success));
         assert_eq!(
-            executor.programs(),
+            backend.programs(),
             vec![OsString::from("first"), OsString::from("second")]
         );
     }
 
-    #[test]
-    fn local_executor_pipes_bytes_to_output_command() {
-        let output = LocalCommandExecutor
-            .output(
-                CommandRequest::new(shell())
-                    .args(["-c", "cat; printf err >&2"])
-                    .stdin(CommandInput::Bytes(b"hello".to_vec())),
-            )
-            .expect("shell command should run");
-
-        assert!(output.status.success());
-        assert_eq!(output.stdout, b"hello");
-        assert_eq!(output.stderr, b"err");
-    }
-
-    #[test]
-    fn local_executor_status_reports_exit_code() {
-        let status = LocalCommandExecutor
-            .status(CommandRequest::new(shell()).args(["-c", "exit 7"]))
-            .expect("shell command should run");
-
-        assert_eq!(status.code(), Some(7));
-    }
-
     #[derive(Default)]
-    struct RecordingExecutor {
+    struct RecordingBackend {
         programs: Mutex<Vec<OsString>>,
     }
 
-    impl RecordingExecutor {
+    impl RecordingBackend {
         fn programs(&self) -> Vec<OsString> {
             self.programs
                 .lock()
@@ -337,28 +344,46 @@ mod tests {
         }
     }
 
-    impl CommandExecutor for RecordingExecutor {
-        fn output(&self, _request: CommandRequest) -> Result<CommandOutput, CommandExecutorError> {
+    impl Backend for RecordingBackend {
+        fn output(&self, _request: CommandRequest) -> Result<CommandOutput, BackendError> {
             panic!("output should not be called by statuses")
         }
 
-        fn status(&self, request: CommandRequest) -> Result<ExitStatus, CommandExecutorError> {
+        fn status(&self, request: CommandRequest) -> Result<ExitStatus, BackendError> {
             self.programs
                 .lock()
                 .expect("program lock should not be poisoned")
                 .push(request.program);
             Ok(status(0))
         }
-    }
 
-    fn shell() -> OsString {
-        std::env::var_os("PATH")
-            .into_iter()
-            .flat_map(|paths| std::env::split_paths(&paths).collect::<Vec<_>>())
-            .flat_map(|path| [path.join("sh"), path.join("bash")])
-            .find(|path| path.exists())
-            .expect("test shell should be available in PATH")
-            .into_os_string()
+        fn home_dir(&self) -> Result<PathBuf, BackendError> {
+            Ok(PathBuf::from("/home/test"))
+        }
+
+        fn current_dir(&self) -> Result<PathBuf, BackendError> {
+            Ok(PathBuf::from("/repo"))
+        }
+
+        fn path_exists(&self, _path: &Path) -> Result<bool, BackendError> {
+            Ok(true)
+        }
+
+        fn path_is_dir(&self, _path: &Path) -> Result<bool, BackendError> {
+            Ok(true)
+        }
+
+        fn create_dir_all(&self, _path: &Path) -> Result<(), BackendError> {
+            Ok(())
+        }
+
+        fn canonicalize(&self, path: &Path) -> Result<PathBuf, BackendError> {
+            Ok(path.to_path_buf())
+        }
+
+        fn validate_program(&self, _program: &OsStr) -> Result<(), BackendError> {
+            Ok(())
+        }
     }
 
     #[cfg(unix)]

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -1,0 +1,164 @@
+use std::{
+    env,
+    ffi::OsStr,
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus, Stdio},
+};
+
+use crate::backend::{Backend, BackendError, CommandInput, CommandOutput, CommandRequest};
+
+/// Local process-backed backend.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LocalBackend;
+
+impl Backend for LocalBackend {
+    fn output(&self, request: CommandRequest) -> Result<CommandOutput, BackendError> {
+        let stdin = request.stdin_config().clone();
+        self.validate_program(request.program())?;
+        let mut child = Command::from(request)
+            .stdin(Stdio::from(stdin.clone()))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        write_stdin(&mut child, &stdin)?;
+
+        let output = child.wait_with_output()?;
+
+        Ok(CommandOutput {
+            status: output.status,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+
+    fn status(&self, request: CommandRequest) -> Result<ExitStatus, BackendError> {
+        let stdin = request.stdin_config().clone();
+        self.validate_program(request.program())?;
+        let mut child = Command::from(request)
+            .stdin(Stdio::from(stdin.clone()))
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        write_stdin(&mut child, &stdin)?;
+
+        child.wait().map_err(BackendError::Io)
+    }
+
+    fn home_dir(&self) -> Result<PathBuf, BackendError> {
+        env::home_dir().ok_or(BackendError::HomeDirNotFound)
+    }
+
+    fn current_dir(&self) -> Result<PathBuf, BackendError> {
+        env::current_dir().map_err(BackendError::Io)
+    }
+
+    fn path_exists(&self, path: &Path) -> Result<bool, BackendError> {
+        Ok(path.exists())
+    }
+
+    fn path_is_dir(&self, path: &Path) -> Result<bool, BackendError> {
+        Ok(path.is_dir())
+    }
+
+    fn create_dir_all(&self, path: &Path) -> Result<(), BackendError> {
+        fs::create_dir_all(path).map_err(BackendError::Io)
+    }
+
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, BackendError> {
+        path.canonicalize().map_err(BackendError::Io)
+    }
+
+    fn validate_program(&self, program: &OsStr) -> Result<(), BackendError> {
+        if program_is_path(program) {
+            let path = Path::new(program);
+            if is_executable_file(path) {
+                return Ok(());
+            }
+        } else if env::var_os("PATH")
+            .into_iter()
+            .flat_map(|paths| env::split_paths(&paths).collect::<Vec<_>>())
+            .map(|path| path.join(program))
+            .any(|path| is_executable_file(&path))
+        {
+            return Ok(());
+        }
+
+        Err(BackendError::MissingProgram(
+            program.to_string_lossy().into_owned(),
+        ))
+    }
+}
+
+fn program_is_path(program: &OsStr) -> bool {
+    let path = Path::new(program);
+    path.is_absolute() || path.components().count() > 1
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+
+    if !metadata.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn write_stdin(child: &mut std::process::Child, stdin: &CommandInput) -> Result<(), BackendError> {
+    if let CommandInput::Bytes(input) = stdin
+        && let Some(mut child_stdin) = child.stdin.take()
+    {
+        match child_stdin.write_all(input) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {}
+            Err(error) => return Err(BackendError::Io(error)),
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::shell;
+    use super::*;
+
+    #[test]
+    fn local_backend_pipes_bytes_to_output_command() {
+        let output = LocalBackend
+            .output(
+                CommandRequest::new(shell())
+                    .args(["-c", "cat; printf err >&2"])
+                    .stdin(CommandInput::Bytes(b"hello".to_vec())),
+            )
+            .expect("shell command should run");
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"hello");
+        assert_eq!(output.stderr, b"err");
+    }
+
+    #[test]
+    fn local_backend_status_reports_exit_code() {
+        let status = LocalBackend
+            .status(CommandRequest::new(shell()).args(["-c", "exit 7"]))
+            .expect("shell command should run");
+
+        assert_eq!(status.code(), Some(7));
+    }
+}

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -3,6 +3,7 @@ use std::{
     ffi::OsStr,
     fs,
     io::{self, Write},
+    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
     process::{Command, ExitStatus, Stdio},
 };
@@ -78,10 +79,8 @@ impl Backend for LocalBackend {
             if is_executable_file(path) {
                 return Ok(());
             }
-        } else if env::var_os("PATH")
+        } else if program_path_candidates(program)
             .into_iter()
-            .flat_map(|paths| env::split_paths(&paths).collect::<Vec<_>>())
-            .map(|path| path.join(program))
             .any(|path| is_executable_file(&path))
         {
             return Ok(());
@@ -98,6 +97,14 @@ fn program_is_path(program: &OsStr) -> bool {
     path.is_absolute() || path.components().count() > 1
 }
 
+fn program_path_candidates(program: &OsStr) -> Vec<PathBuf> {
+    env::var_os("PATH")
+        .into_iter()
+        .flat_map(|paths| env::split_paths(&paths).collect::<Vec<_>>())
+        .map(|path| path.join(program))
+        .collect()
+}
+
 fn is_executable_file(path: &Path) -> bool {
     let Ok(metadata) = fs::metadata(path) else {
         return false;
@@ -107,16 +114,7 @@ fn is_executable_file(path: &Path) -> bool {
         return false;
     }
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        metadata.permissions().mode() & 0o111 != 0
-    }
-
-    #[cfg(not(unix))]
-    {
-        true
-    }
+    metadata.permissions().mode() & 0o111 != 0
 }
 
 fn write_stdin(child: &mut std::process::Child, stdin: &CommandInput) -> Result<(), BackendError> {
@@ -160,5 +158,21 @@ mod tests {
             .expect("shell command should run");
 
         assert_eq!(status.code(), Some(7));
+    }
+
+    #[test]
+    fn local_backend_validates_path_programs() {
+        LocalBackend
+            .validate_program(&shell())
+            .expect("shell path should validate");
+    }
+
+    #[test]
+    fn local_backend_rejects_missing_programs() {
+        let err = LocalBackend
+            .validate_program(OsStr::new("piquel-definitely-missing-program"))
+            .expect_err("missing program should be rejected");
+
+        assert!(matches!(err, BackendError::MissingProgram(_)));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,9 +4,9 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 
 use crate::{
-    Config, config,
-    executor::{CommandExecutor, LocalCommandExecutor},
-    tmux,
+    Config,
+    backend::{Backend, LocalBackend},
+    config, tmux,
 };
 
 mod projects;
@@ -81,21 +81,22 @@ pub enum ProjectCommands {
 /// Runtime state shared by CLI command handlers.
 pub struct State {
     config: Config,
-    executor: Box<dyn CommandExecutor>,
+    backend: Box<dyn Backend>,
 }
 
 impl State {
     /// Creates CLI state from loaded configuration.
     #[must_use]
     pub fn new(config: Config) -> Self {
-        Self {
-            config,
-            executor: Box::<LocalCommandExecutor>::default(),
-        }
+        Self::with_backend(config, Box::<LocalBackend>::default())
     }
 
-    pub(crate) fn executor(&self) -> &dyn CommandExecutor {
-        self.executor.as_ref()
+    pub(crate) fn with_backend(config: Config, backend: Box<dyn Backend>) -> Self {
+        Self { config, backend }
+    }
+
+    pub(crate) fn backend(&self) -> &dyn Backend {
+        self.backend.as_ref()
     }
 
     /// Lists running tmux sessions.
@@ -104,7 +105,7 @@ impl State {
     ///
     /// Returns an error if tmux session listing fails.
     pub fn list(&self) -> Result<()> {
-        let mut sessions = tmux::list_sessions(self.executor())?;
+        let mut sessions = tmux::list_sessions(self.backend())?;
         sessions.sort();
         sessions.dedup();
 
@@ -124,20 +125,23 @@ impl State {
 /// cannot be loaded, or the selected command fails.
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
+    let backend: Box<dyn Backend> = Box::<LocalBackend>::default();
 
     let config_path = cli
         .config_path
         .or_else(|| std::env::var_os(CONFIG_ENV_VAR).map(PathBuf::from))
         .map_or_else(
             || {
-                std::env::home_dir()
+                backend
+                    .home_dir()
                     .context("home directory not found")
                     .map(|home| home.join(".config/piquel/config.json"))
             },
             Ok,
         )?;
 
-    let state = State::new(config::load_config(&config_path)?);
+    let config = config::load_config(&config_path, backend.as_ref())?;
+    let state = State::with_backend(config, backend);
 
     match &cli.command {
         Commands::List => state.list(),

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs,
-    io::{self, Write},
-};
+use std::io::{self, Write};
 
 use anyhow::{Context, Result, anyhow, bail};
 
@@ -64,7 +61,7 @@ impl State {
 
         match worktree {
             Some(branch) => self.open_project_branch(&project, template, branch)?,
-            None => tmux::open_session(self.executor(), &project.name, &project.path, template)?,
+            None => tmux::open_session(self.backend(), &project.name, &project.path, template)?,
         }
 
         Ok(())
@@ -102,7 +99,7 @@ impl State {
 
         let branches = self.list_local_branches(&project.path)?;
         if branches.is_empty() {
-            tmux::open_session(self.executor(), &project.name, &project.path, template)?;
+            tmux::open_session(self.backend(), &project.name, &project.path, template)?;
             return Ok(());
         }
 
@@ -134,13 +131,14 @@ impl State {
             worktree.path
         } else {
             let worktree_path = git::managed_worktree_path_for_branch(
+                self.backend(),
                 &self.config.worktrees_dir,
                 &project.name,
                 branch,
                 &worktrees,
             )?;
             if let Some(parent) = worktree_path.parent() {
-                fs::create_dir_all(parent).with_context(|| {
+                self.backend().create_dir_all(parent).with_context(|| {
                     format!(
                         "Failed to create managed worktree directory {}",
                         parent.display()
@@ -152,21 +150,22 @@ impl State {
         };
 
         let tmux_name = format!("{}--{branch}", project.name);
-        tmux::open_session(self.executor(), &tmux_name, &root, template)?;
+        tmux::open_session(self.backend(), &tmux_name, &root, template)?;
         Ok(())
     }
 
     fn list_local_branches(&self, project_path: &std::path::Path) -> Result<Vec<String>> {
-        let output = self
-            .executor()
-            .output(git::list_local_branches_request(project_path)?)?;
+        let output = self.backend().output(git::list_local_branches_request(
+            self.backend(),
+            project_path,
+        )?)?;
         Ok(git::parse_local_branches_output(&output)?)
     }
 
     fn list_worktrees(&self, project_path: &std::path::Path) -> Result<Vec<git::Worktree>> {
         let output = self
-            .executor()
-            .output(git::list_worktrees_request(project_path)?)?;
+            .backend()
+            .output(git::list_worktrees_request(self.backend(), project_path)?)?;
         Ok(git::parse_worktrees_output(&output)?)
     }
 
@@ -176,7 +175,7 @@ impl State {
         worktree_path: &std::path::Path,
         branch: &str,
     ) -> Result<()> {
-        let output = self.executor().output(git::create_worktree_request(
+        let output = self.backend().output(git::create_worktree_request(
             project_path,
             worktree_path,
             branch,
@@ -185,8 +184,8 @@ impl State {
     }
 
     fn ensure_project_path(&self, project: &ResolvedProject) -> Result<()> {
-        if project.path.exists() {
-            if !project.path.is_dir() {
+        if self.backend().path_exists(&project.path)? {
+            if !self.backend().path_is_dir(&project.path)? {
                 bail!(
                     "Project \"{}\" path {} is not a directory",
                     project.name,
@@ -204,7 +203,7 @@ impl State {
             );
         }
 
-        clone_project(self.executor(), project)
+        clone_project(self.backend(), project)
     }
 }
 
@@ -228,12 +227,9 @@ fn prompt_clone_project(project: &ResolvedProject) -> Result<bool> {
     ))
 }
 
-fn clone_project(
-    executor: &dyn crate::executor::CommandExecutor,
-    project: &ResolvedProject,
-) -> Result<()> {
+fn clone_project(backend: &dyn crate::backend::Backend, project: &ResolvedProject) -> Result<()> {
     if let Some(parent) = project.path.parent() {
-        fs::create_dir_all(parent).with_context(|| {
+        backend.create_dir_all(parent).with_context(|| {
             format!(
                 "Failed to create project parent directory {}",
                 parent.display()
@@ -241,7 +237,7 @@ fn clone_project(
         })?;
     }
 
-    let status = executor.status(git::clone_repository_request(
+    let status = backend.status(git::clone_repository_request(
         &project.repository,
         &project.path,
     ))?;

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 
-use crate::{cli::State, fzf, tmux};
+use crate::{backend::Backend, cli::State, fzf, tmux};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PickTarget {
@@ -29,7 +29,7 @@ impl State {
         match self.pick_target()? {
             Some(PickTarget::TmuxSession(name)) => {
                 tmux::err_in_tmux()?;
-                tmux::attach(self.executor(), &name)?;
+                tmux::attach(self.backend(), &name)?;
             }
             Some(PickTarget::Project(name)) => {
                 self.open_project_interactive(&name, session_override)?;
@@ -61,13 +61,13 @@ impl State {
             .session_template(template_name)
             .ok_or_else(|| anyhow!("Session template \"{template_name}\" is not configured"))?;
 
-        let root = resolve_session_root(path)?;
+        let root = resolve_session_root(self.backend(), path)?;
 
-        if !root.exists() {
+        if !self.backend().path_exists(&root)? {
             bail!("Session path {} does not exist", root.display());
         }
 
-        if !root.is_dir() {
+        if !self.backend().path_is_dir(&root)? {
             bail!("Session path {} is not a directory", root.display());
         }
 
@@ -82,7 +82,7 @@ impl State {
                 .into_owned(),
         };
 
-        tmux::open_session(self.executor(), &tmux_name, &root, template)?;
+        tmux::open_session(self.backend(), &tmux_name, &root, template)?;
         Ok(())
     }
 
@@ -92,7 +92,7 @@ impl State {
             .projects
             .iter()
             .filter_map(|project| project.resolved_name().ok());
-        let tmux_sessions = tmux::list_sessions(self.executor())?;
+        let tmux_sessions = tmux::list_sessions(self.backend())?;
         let (items, mut targets) = build_pick_targets(tmux_sessions, project_names);
 
         let Some(selection) = Self::select_fzf(items, "piquel> ")? else {
@@ -113,22 +113,15 @@ impl State {
     }
 }
 
-fn expand_home(path: &Path) -> PathBuf {
-    if let Ok(stripped) = path.strip_prefix("~")
-        && let Some(home) = std::env::home_dir()
-    {
-        return home.join(stripped);
-    }
-    path.to_path_buf()
-}
-
-fn resolve_session_root(path: Option<&Path>) -> Result<PathBuf> {
+fn resolve_session_root(backend: &dyn Backend, path: Option<&Path>) -> Result<PathBuf> {
     match path {
-        Some(path) if path == Path::new(".") => {
-            std::env::current_dir().context("Failed to determine current directory")
-        }
-        Some(path) => Ok(expand_home(path)),
-        None => std::env::current_dir().context("Failed to determine current directory"),
+        Some(path) if path == Path::new(".") => backend
+            .current_dir()
+            .context("Failed to determine current directory"),
+        Some(path) => Ok(backend.expand_home(path)?),
+        None => backend
+            .current_dir()
+            .context("Failed to determine current directory"),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::Config;
+use crate::{Config, backend::Backend};
 use thiserror::Error;
 
 /// Errors produced while loading or accessing the CLI config.
@@ -15,6 +15,9 @@ pub enum ConfigError {
     /// The parsed config failed semantic validation.
     #[error("{0}")]
     Validation(String),
+    /// A backend operation failed while normalizing config.
+    #[error("{0}")]
+    Backend(#[from] crate::backend::BackendError),
 }
 
 /// Loads the JSON config from `config_path`.
@@ -23,11 +26,11 @@ pub enum ConfigError {
 ///
 /// Returns an error if the file cannot be read, the JSON cannot be parsed, or
 /// validation fails.
-pub fn load_config(config_path: &Path) -> Result<Config, ConfigError> {
+pub fn load_config(config_path: &Path, backend: &dyn Backend) -> Result<Config, ConfigError> {
     let config_file = std::fs::read_to_string(config_path)
         .map_err(|_| ConfigError::FileNotFound(config_path.to_owned()))?;
 
     let mut parsed: Config = serde_json::from_str(&config_file).map_err(ConfigError::ParseError)?;
-    parsed.validate_and_normalize()?;
+    parsed.validate_and_normalize(backend)?;
     Ok(parsed)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use thiserror::Error;
 
-use crate::executor::{CommandExecutorError, CommandOutput, CommandRequest};
+use crate::backend::{Backend, BackendError, CommandOutput, CommandRequest};
 
 /// A git worktree discovered from `git worktree list --porcelain`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,6 +21,9 @@ pub enum GitError {
     /// The git process could not be spawned or observed.
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
+    /// A backend operation failed.
+    #[error("{0}")]
+    Backend(BackendError),
     /// git exited unsuccessfully.
     #[error("{0}")]
     Command(String),
@@ -51,10 +54,11 @@ pub enum GitError {
     Parse(String),
 }
 
-impl From<CommandExecutorError> for GitError {
-    fn from(value: CommandExecutorError) -> Self {
+impl From<BackendError> for GitError {
+    fn from(value: BackendError) -> Self {
         match value {
-            CommandExecutorError::Io(err) => GitError::Io(err),
+            BackendError::Io(err) => GitError::Io(err),
+            error => GitError::Backend(error),
         }
     }
 }
@@ -64,8 +68,11 @@ impl From<CommandExecutorError> for GitError {
 /// # Errors
 ///
 /// Returns an error if `project_path` does not exist.
-pub fn list_local_branches_request(project_path: &Path) -> Result<CommandRequest, GitError> {
-    if !project_path.exists() {
+pub fn list_local_branches_request(
+    backend: &dyn Backend,
+    project_path: &Path,
+) -> Result<CommandRequest, GitError> {
+    if !backend.path_exists(project_path)? {
         return Err(GitError::MissingProjectPath(project_path.to_owned()));
     }
 
@@ -130,8 +137,11 @@ pub fn parse_create_worktree_output(output: &CommandOutput) -> Result<(), GitErr
 /// # Errors
 ///
 /// Returns an error if `project_path` does not exist.
-pub fn list_worktrees_request(project_path: &Path) -> Result<CommandRequest, GitError> {
-    if !project_path.exists() {
+pub fn list_worktrees_request(
+    backend: &dyn Backend,
+    project_path: &Path,
+) -> Result<CommandRequest, GitError> {
+    if !backend.path_exists(project_path)? {
         return Err(GitError::MissingProjectPath(project_path.to_owned()));
     }
 
@@ -252,7 +262,11 @@ fn push_worktree(
 
 /// Returns whether `worktrees` includes a branch worktree beyond `project_path`.
 #[must_use]
-pub fn has_additional_worktrees(project_path: &Path, worktrees: &[Worktree]) -> bool {
+pub fn has_additional_worktrees(
+    backend: &dyn Backend,
+    project_path: &Path,
+    worktrees: &[Worktree],
+) -> bool {
     let branch_worktrees = worktrees
         .iter()
         .filter(|worktree| worktree.branch.is_some())
@@ -261,15 +275,15 @@ pub fn has_additional_worktrees(project_path: &Path, worktrees: &[Worktree]) -> 
     branch_worktrees.len() > 1
         || branch_worktrees
             .iter()
-            .any(|worktree| !same_path(&worktree.path, project_path))
+            .any(|worktree| !same_path(backend, &worktree.path, project_path))
 }
 
-fn same_path(left: &Path, right: &Path) -> bool {
+fn same_path(backend: &dyn Backend, left: &Path, right: &Path) -> bool {
     if left == right {
         return true;
     }
 
-    match (left.canonicalize(), right.canonicalize()) {
+    match (backend.canonicalize(left), backend.canonicalize(right)) {
         (Ok(left), Ok(right)) => left == right,
         _ => false,
     }
@@ -311,6 +325,7 @@ pub fn managed_worktree_path(
 /// Returns an error if the branch path cannot be generated or if an existing
 /// path is not already registered as `branch`'s worktree.
 pub fn managed_worktree_path_for_branch(
+    backend: &dyn Backend,
     worktrees_dir: &Path,
     project_name: &str,
     branch: &str,
@@ -318,9 +333,9 @@ pub fn managed_worktree_path_for_branch(
 ) -> Result<PathBuf, GitError> {
     let path = managed_worktree_path(worktrees_dir, project_name, branch)?;
 
-    if path.exists()
+    if backend.path_exists(&path)?
         && !worktrees.iter().any(|worktree| {
-            same_path(&worktree.path, &path) && worktree.branch.as_deref() == Some(branch)
+            same_path(backend, &worktree.path, &path) && worktree.branch.as_deref() == Some(branch)
         })
     {
         return Err(GitError::ManagedWorktreePathConflict {
@@ -361,6 +376,7 @@ fn sanitized_branch_segment(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::LocalBackend;
 
     #[test]
     fn parses_multiple_worktrees_and_branch_names_with_slashes() {
@@ -535,14 +551,15 @@ main
 
     #[test]
     fn request_builders_reject_missing_project_paths() {
+        let backend = LocalBackend;
         let missing = Path::new("/definitely/missing/piquel/project");
 
         assert!(matches!(
-            list_local_branches_request(missing),
+            list_local_branches_request(&backend, missing),
             Err(GitError::MissingProjectPath(_))
         ));
         assert!(matches!(
-            list_worktrees_request(missing),
+            list_worktrees_request(&backend, missing),
             Err(GitError::MissingProjectPath(_))
         ));
     }
@@ -597,8 +614,9 @@ main
         let existing = root.join("alpha/feature_foo");
         std::fs::create_dir_all(&existing).expect("test directory should be created");
 
-        let err = managed_worktree_path_for_branch(&root, "alpha", "feature/foo", &[])
-            .expect_err("existing unregistered path should be rejected");
+        let err =
+            managed_worktree_path_for_branch(&LocalBackend, &root, "alpha", "feature/foo", &[])
+                .expect_err("existing unregistered path should be rejected");
 
         assert!(matches!(err, GitError::ManagedWorktreePathConflict { .. }));
 
@@ -618,6 +636,7 @@ main
         std::fs::create_dir_all(&existing).expect("test directory should be created");
 
         let path = managed_worktree_path_for_branch(
+            &LocalBackend,
             &root,
             "alpha",
             "feature/foo",
@@ -671,7 +690,11 @@ main
             worktree("/repo-detached", None),
         ];
 
-        assert!(!has_additional_worktrees(project_path, &worktrees));
+        assert!(!has_additional_worktrees(
+            &LocalBackend,
+            project_path,
+            &worktrees
+        ));
     }
 
     #[test]
@@ -679,6 +702,7 @@ main
         let project_path = Path::new("/repo");
 
         assert!(has_additional_worktrees(
+            &LocalBackend,
             project_path,
             &[
                 worktree("/repo", Some("main")),
@@ -686,6 +710,7 @@ main
             ]
         ));
         assert!(has_additional_worktrees(
+            &LocalBackend,
             project_path,
             &[worktree("/repo-feature", Some("feature/foo"))]
         ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 //! Data types and helpers for the `piquelcli` command-line tool.
 
+/// Machine interaction backend abstraction.
+pub mod backend;
 /// Command-line parsing and top-level dispatch.
 pub mod cli;
 /// JSON config loading.
 pub mod config;
-/// Command execution and user output abstraction.
-pub mod executor;
 /// Interactive fuzzy selection helpers.
 pub mod fzf;
 /// Git worktree discovery helpers.
@@ -19,7 +19,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::config::ConfigError;
+use crate::{backend::Backend, config::ConfigError};
 
 /// Commands to send to a tmux window after creating it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -107,9 +107,13 @@ impl ProjectConfig {
     /// # Errors
     ///
     /// Returns an error if the project name cannot be resolved.
-    pub fn resolved_path(&self, projects_dir: &Path) -> Result<PathBuf, ConfigError> {
+    pub fn resolved_path(
+        &self,
+        backend: &dyn Backend,
+        projects_dir: &Path,
+    ) -> Result<PathBuf, ConfigError> {
         match &self.path {
-            Some(path) => Ok(expand_home(path)),
+            Some(path) => Ok(backend.expand_home(path)?),
             None => Ok(projects_dir.join(self.resolved_name()?)),
         }
     }
@@ -156,9 +160,9 @@ impl Config {
     ///
     /// Returns an error if session templates, project names, project paths, or
     /// default-session references are invalid.
-    pub fn validate_and_normalize(&mut self) -> Result<(), ConfigError> {
-        self.projects_dir = expand_home(&self.projects_dir);
-        self.worktrees_dir = expand_home(&self.worktrees_dir);
+    pub fn validate_and_normalize(&mut self, backend: &dyn Backend) -> Result<(), ConfigError> {
+        self.projects_dir = backend.expand_home(&self.projects_dir)?;
+        self.worktrees_dir = backend.expand_home(&self.worktrees_dir)?;
 
         for (name, session) in &self.sessions {
             session.validate(name)?;
@@ -182,7 +186,7 @@ impl Config {
                 )));
             }
 
-            let path = project.resolved_path(&self.projects_dir)?;
+            let path = project.resolved_path(backend, &self.projects_dir)?;
             project.name = Some(name);
             project.path = Some(path);
 
@@ -227,10 +231,15 @@ impl Config {
                 return None;
             }
 
+            let path = project
+                .path
+                .clone()
+                .unwrap_or_else(|| self.projects_dir.join(&resolved_name));
+
             Some(ResolvedProject {
                 repository: project.repository.clone(),
                 name: resolved_name,
-                path: project.resolved_path(&self.projects_dir).ok()?,
+                path,
                 default_session: project.resolved_default_session(self),
             })
         })
@@ -261,16 +270,6 @@ pub struct ResolvedProject {
     name: String,
     path: PathBuf,
     default_session: ProjectSessionConfig,
-}
-
-/// Replaces '~' with the contents of $HOME
-fn expand_home(path: &Path) -> PathBuf {
-    if let Ok(stripped) = path.strip_prefix("~")
-        && let Some(home) = std::env::home_dir()
-    {
-        return home.join(stripped);
-    }
-    path.to_path_buf()
 }
 
 fn default_projects_dir() -> PathBuf {
@@ -314,6 +313,7 @@ fn validate_project_name(name: &str) -> Result<(), ConfigError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::LocalBackend;
 
     fn window() -> WindowConfig {
         WindowConfig {
@@ -338,6 +338,10 @@ mod tests {
         }
     }
 
+    fn backend() -> LocalBackend {
+        LocalBackend
+    }
+
     #[test]
     fn expands_projects_dir_worktrees_dir_and_project_path() {
         let home = std::env::home_dir().expect("HOME should be set for tests");
@@ -350,7 +354,7 @@ mod tests {
         });
 
         config
-            .validate_and_normalize()
+            .validate_and_normalize(&backend())
             .expect("config should validate");
 
         assert_eq!(config.projects_dir, home.join("Projects"));
@@ -372,7 +376,7 @@ mod tests {
         .expect("config should parse");
 
         config
-            .validate_and_normalize()
+            .validate_and_normalize(&backend())
             .expect("config should validate");
 
         assert_eq!(config.worktrees_dir, home.join(".piquel/worktrees"));
@@ -455,7 +459,7 @@ mod tests {
             projects: vec![],
         };
 
-        assert!(config.validate_and_normalize().is_err());
+        assert!(config.validate_and_normalize(&backend()).is_err());
     }
 
     #[test]
@@ -470,7 +474,7 @@ mod tests {
             };
 
             assert!(
-                config.validate_and_normalize().is_err(),
+                config.validate_and_normalize(&backend()).is_err(),
                 "{name:?} should be rejected as a template name"
             );
         }
@@ -486,7 +490,7 @@ mod tests {
             projects: vec![],
         };
 
-        assert!(config.validate_and_normalize().is_err());
+        assert!(config.validate_and_normalize(&backend()).is_err());
     }
 
     #[test]
@@ -507,7 +511,7 @@ mod tests {
             },
         ];
 
-        assert!(config.validate_and_normalize().is_err());
+        assert!(config.validate_and_normalize(&backend()).is_err());
     }
 
     #[test]
@@ -520,7 +524,7 @@ mod tests {
             default_session: Some(ProjectSessionConfig::Template("missing".to_owned())),
         });
 
-        assert!(config.validate_and_normalize().is_err());
+        assert!(config.validate_and_normalize(&backend()).is_err());
     }
 
     #[test]
@@ -539,7 +543,7 @@ mod tests {
         });
 
         config
-            .validate_and_normalize()
+            .validate_and_normalize(&backend())
             .expect("config should validate");
         let project = config.project("repo").expect("project should resolve");
 
@@ -561,7 +565,7 @@ mod tests {
             })),
         });
 
-        assert!(config.validate_and_normalize().is_err());
+        assert!(config.validate_and_normalize(&backend()).is_err());
     }
 
     #[test]
@@ -577,7 +581,7 @@ mod tests {
             },
         );
 
-        assert!(config.validate_and_normalize().is_err());
+        assert!(config.validate_and_normalize(&backend()).is_err());
     }
 
     #[test]
@@ -592,7 +596,7 @@ mod tests {
         });
 
         config
-            .validate_and_normalize()
+            .validate_and_normalize(&backend())
             .expect("config should validate");
 
         assert_eq!(
@@ -613,7 +617,7 @@ mod tests {
         });
 
         config
-            .validate_and_normalize()
+            .validate_and_normalize(&backend())
             .expect("config should validate");
         let project = config.project("repo").expect("project should exist");
 
@@ -645,7 +649,7 @@ mod tests {
             default_session: Some(ProjectSessionConfig::Template("rust".to_owned())),
         });
         config
-            .validate_and_normalize()
+            .validate_and_normalize(&backend())
             .expect("config should validate");
         let project = config.project("repo").expect("project should exist");
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,8 +1,7 @@
 use crate::{
     SessionConfig, WindowConfig,
-    executor::{
-        CommandExecutor, CommandExecutorError, CommandInput, CommandOutput, CommandRequest,
-        CommandRequests,
+    backend::{
+        Backend, BackendError, CommandInput, CommandOutput, CommandRequest, CommandRequests,
     },
 };
 use std::io;
@@ -16,6 +15,9 @@ pub enum TmuxError {
     /// The tmux process could not be spawned or observed.
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
+    /// A backend operation failed.
+    #[error("{0}")]
+    Backend(BackendError),
     /// tmux exited unsuccessfully or returned an unexpected response.
     #[error("{0}")]
     Command(String),
@@ -27,10 +29,11 @@ pub enum TmuxError {
     InvalidSessionName(String),
 }
 
-impl From<CommandExecutorError> for TmuxError {
-    fn from(value: CommandExecutorError) -> Self {
+impl From<BackendError> for TmuxError {
+    fn from(value: BackendError) -> Self {
         match value {
-            CommandExecutorError::Io(err) => TmuxError::Io(err),
+            BackendError::Io(err) => TmuxError::Io(err),
+            error => TmuxError::Backend(error),
         }
     }
 }
@@ -41,13 +44,13 @@ pub fn list_sessions_request() -> CommandRequest {
     tmux_request(["list-sessions", "-F", "#{session_name}"])
 }
 
-/// Lists running tmux sessions through `executor`.
+/// Lists running tmux sessions through `backend`.
 ///
 /// # Errors
 ///
 /// Returns an error if tmux cannot be invoked or returns an unexpected failure.
-pub fn list_sessions(executor: &dyn CommandExecutor) -> Result<Vec<String>, TmuxError> {
-    let output = executor.output(list_sessions_request())?;
+pub fn list_sessions(backend: &dyn Backend) -> Result<Vec<String>, TmuxError> {
+    let output = backend.output(list_sessions_request())?;
     parse_list_sessions_output(&output)
 }
 
@@ -85,13 +88,13 @@ pub fn attach_request(session: &str) -> CommandRequest {
     tmux_request(["attach", "-t", session])
 }
 
-/// Attaches to an existing tmux session through `executor`.
+/// Attaches to an existing tmux session through `backend`.
 ///
 /// # Errors
 ///
 /// Returns an error if tmux cannot attach to the requested session.
-pub fn attach(executor: &dyn CommandExecutor, name: &str) -> Result<String, TmuxError> {
-    let output = executor.output(attach_request(name))?;
+pub fn attach(backend: &dyn Backend, name: &str) -> Result<String, TmuxError> {
+    let output = backend.output(attach_request(name))?;
     successful_output(&output)
 }
 
@@ -172,20 +175,20 @@ pub fn select_window_request(window_id: &str) -> CommandRequest {
 ///
 /// Returns an error if the session name is invalid or any tmux command fails.
 pub fn open_session(
-    executor: &dyn CommandExecutor,
+    backend: &dyn Backend,
     tmux_name: &str,
     root: &Path,
     template: &SessionConfig,
 ) -> Result<(), TmuxError> {
     let tmux_name = validated_session_name(tmux_name)?;
 
-    let sessions = list_sessions(executor)?;
+    let sessions = list_sessions(backend)?;
     if sessions.contains(&tmux_name) {
-        attach(executor, &tmux_name)?;
+        attach(backend, &tmux_name)?;
         return Ok(());
     }
 
-    let status = executor
+    let status = backend
         .status(new_session_request(&tmux_name, root))
         .map_err(|_| {
             TmuxError::Command(format!("Failed to create session with name {tmux_name}"))
@@ -194,7 +197,7 @@ pub fn open_session(
         TmuxError::Command(format!("Failed to create session with name {tmux_name}"))
     })?;
 
-    let output = executor
+    let output = backend
         .output(list_windows_request(&tmux_name))
         .map_err(|e| TmuxError::Command(format!("Failed to list tmux windows with error: {e}")))?;
     let bootstrap_window = successful_output(&output)
@@ -203,28 +206,28 @@ pub fn open_session(
     let mut first_window = None;
 
     for (i, window) in template.windows.iter().enumerate() {
-        let window_id = create_window(executor, &tmux_name, root, window).map_err(|e| {
+        let window_id = create_window(backend, &tmux_name, root, window).map_err(|e| {
             TmuxError::Command(format!("Failed to create window {} with error: {e}", i + 1))
         })?;
 
         first_window.get_or_insert(window_id);
     }
 
-    let status = executor
+    let status = backend
         .status(kill_window_request(&bootstrap_window))
         .map_err(|_| TmuxError::Command("Failed to kill first window".to_owned()))?;
     successful_status(status)
         .map_err(|_| TmuxError::Command("Failed to kill first window".to_owned()))?;
 
     if let Some(first_window) = first_window {
-        let status = executor
+        let status = backend
             .status(select_window_request(&first_window))
             .map_err(|_| TmuxError::Command("Failed to select first window".to_owned()))?;
         successful_status(status)
             .map_err(|_| TmuxError::Command("Failed to select first window".to_owned()))?;
     }
 
-    attach(executor, &tmux_name).map_err(|_| {
+    attach(backend, &tmux_name).map_err(|_| {
         TmuxError::Command(format!(
             "Failed to attach to session with error: {tmux_name}"
         ))
@@ -348,12 +351,12 @@ fn tmux_request<'a>(args: impl IntoIterator<Item = &'a str>) -> CommandRequest {
 }
 
 fn create_window(
-    executor: &dyn CommandExecutor,
+    backend: &dyn Backend,
     session_name: &str,
     start_dir: &Path,
     window: &WindowConfig,
 ) -> Result<String, TmuxError> {
-    let output = executor
+    let output = backend
         .output(new_window_request(session_name, start_dir, window))
         .map_err(|e| TmuxError::Command(format!("Failed to create window with error: {e}")))?;
     let window_id = successful_output(&output)
@@ -361,7 +364,7 @@ fn create_window(
     let window_id = window_id.trim_matches('\n').to_owned();
 
     for command in &window.commands {
-        let output = executor
+        let output = backend
             .output(send_keys_request(&window_id, command))
             .map_err(|e| {
                 TmuxError::Command(format!(
@@ -535,7 +538,7 @@ mod tests {
 
     #[test]
     fn open_session_attaches_when_session_already_exists() {
-        let executor = RecordingExecutor::new(vec![
+        let backend = RecordingBackend::new(vec![
             command_output(0, b"alpha\nbeta\n", b""),
             command_output(0, b"", b""),
         ]);
@@ -546,19 +549,19 @@ mod tests {
             }],
         };
 
-        open_session(&executor, "alpha", Path::new("/repo"), &template)
+        open_session(&backend, "alpha", Path::new("/repo"), &template)
             .expect("existing session should attach");
 
         assert_eq!(
-            executor.output_requests(),
+            backend.output_requests(),
             vec![list_sessions_request(), attach_request("alpha")]
         );
-        assert!(executor.status_requests().is_empty());
+        assert!(backend.status_requests().is_empty());
     }
 
     #[test]
     fn open_session_creates_windows_selects_first_and_attaches() {
-        let executor = RecordingExecutor::new(vec![
+        let backend = RecordingBackend::new(vec![
             command_output(0, b"", b""),
             command_output(0, b"@0\n", b""),
             command_output(0, b"@1\n", b""),
@@ -580,11 +583,11 @@ mod tests {
             ],
         };
 
-        open_session(&executor, "feature/foo", Path::new("/repo"), &template)
+        open_session(&backend, "feature/foo", Path::new("/repo"), &template)
             .expect("new session should be created");
 
         assert_eq!(
-            executor.output_requests(),
+            backend.output_requests(),
             vec![
                 list_sessions_request(),
                 list_windows_request("feature_foo"),
@@ -596,7 +599,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            executor.status_requests(),
+            backend.status_requests(),
             vec![
                 new_session_request("feature_foo", Path::new("/repo")),
                 kill_window_request("@0"),
@@ -605,13 +608,13 @@ mod tests {
         );
     }
 
-    struct RecordingExecutor {
+    struct RecordingBackend {
         output_responses: Mutex<VecDeque<CommandOutput>>,
         output_requests: Mutex<Vec<CommandRequest>>,
         status_requests: Mutex<Vec<CommandRequest>>,
     }
 
-    impl RecordingExecutor {
+    impl RecordingBackend {
         fn new(output_responses: Vec<CommandOutput>) -> Self {
             Self {
                 output_responses: Mutex::new(output_responses.into()),
@@ -635,8 +638,8 @@ mod tests {
         }
     }
 
-    impl CommandExecutor for RecordingExecutor {
-        fn output(&self, request: CommandRequest) -> Result<CommandOutput, CommandExecutorError> {
+    impl Backend for RecordingBackend {
+        fn output(&self, request: CommandRequest) -> Result<CommandOutput, BackendError> {
             self.output_requests
                 .lock()
                 .expect("requests lock should not be poisoned")
@@ -649,12 +652,40 @@ mod tests {
                 .expect("test output response should exist"))
         }
 
-        fn status(&self, request: CommandRequest) -> Result<ExitStatus, CommandExecutorError> {
+        fn status(&self, request: CommandRequest) -> Result<ExitStatus, BackendError> {
             self.status_requests
                 .lock()
                 .expect("requests lock should not be poisoned")
                 .push(request);
             Ok(status(0))
+        }
+
+        fn home_dir(&self) -> Result<std::path::PathBuf, BackendError> {
+            Ok(std::path::PathBuf::from("/home/test"))
+        }
+
+        fn current_dir(&self) -> Result<std::path::PathBuf, BackendError> {
+            Ok(std::path::PathBuf::from("/repo"))
+        }
+
+        fn path_exists(&self, _path: &Path) -> Result<bool, BackendError> {
+            Ok(true)
+        }
+
+        fn path_is_dir(&self, _path: &Path) -> Result<bool, BackendError> {
+            Ok(true)
+        }
+
+        fn create_dir_all(&self, _path: &Path) -> Result<(), BackendError> {
+            Ok(())
+        }
+
+        fn canonicalize(&self, path: &Path) -> Result<std::path::PathBuf, BackendError> {
+            Ok(path.to_path_buf())
+        }
+
+        fn validate_program(&self, _program: &std::ffi::OsStr) -> Result<(), BackendError> {
+            Ok(())
         }
     }
 


### PR DESCRIPTION
## Summary
- Renamed the command executor layer to `Backend` and moved the local implementation into `src/backend/local.rs`.
- Updated CLI, config, git, and tmux flows to route filesystem, path, and program checks through the backend abstraction.
- Centralized home expansion, directory handling, canonicalization, and program validation behind backend APIs.
- Adjusted docs to describe the new backend model and the separation between backend actions and local feedback actions.