### PR TITLE
feat: SSH machines support for remote workspace commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ piquel -m pi project load piquel-cli
 
 The config file itself is always read locally. When a machine is selected,
 tmux, git, path checks, `~` expansion, directory creation, and program
-validation run through `ssh -t <username>@<address> ...`.
+validation run over SSH. Non-interactive commands use `ssh -T`; attaching to
+tmux uses `ssh -t` so the remote session gets a terminal.
 
 The branch picker lists local git branches only. It does not fetch and does not
 create remote-tracking branches. If the selected branch already has a worktree,

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ session or project interactively.
 - `tmux` for session commands
 - `fzf` for `piquel pick`
 - `git` when using project worktree selection
+- `ssh` when using `-m/--machine` for remote machines
 
 ## Install
 
@@ -41,17 +42,28 @@ piquel --config examples/test-config.json project list
 Commands:
 
 ```text
-piquel list
-piquel pick [project] [--session <template>]
+piquel [-m <machine>] list
+piquel [-m <machine>] pick [project] [--session <template>]
 piquel project list
-piquel project load <project> [--session <template>] [--worktree <branch>]
-piquel session [path] [--session <template>] [--name <tmux-name>]
+piquel [-m <machine>] project load <project> [--session <template>] [--worktree <branch>]
+piquel [-m <machine>] session [path] [--session <template>] [--name <tmux-name>]
 ```
 
 `piquel list` prints running tmux sessions. `piquel pick` combines running
 tmux sessions and configured projects, lets `fzf` select one, then attaches to
 the session or opens the project branch workflow. `piquel pick <project>` skips
 the first picker and opens that project's branch workflow directly.
+
+Use `-m/--machine` to run workspace commands on a configured remote machine:
+
+```sh
+piquel -m pi pick
+piquel -m pi project load piquel-cli
+```
+
+The config file itself is always read locally. When a machine is selected,
+tmux, git, path checks, `~` expansion, directory creation, and program
+validation run through `ssh -t <username>@<address> ...`.
 
 The branch picker lists local git branches only. It does not fetch and does not
 create remote-tracking branches. If the selected branch already has a worktree,
@@ -129,6 +141,13 @@ Fuller project config:
       ]
     }
   },
+  "machines": [
+    {
+      "name": "pi",
+      "address": "pi.local",
+      "username": "ronan"
+    }
+  ],
   "projects": [
     {
       "repository": "git@github.com:PiquelChips/piquel-cli.git",
@@ -163,6 +182,8 @@ Fields:
   one window.
 - `projects`: configured repositories. The project name is derived from the
   repository basename unless `name` is set.
+- `machines`: configured SSH machines. `name` is passed to `-m/--machine`,
+  while `address` and `username` form the SSH target.
 - `projects[].path`: explicit project path. Defaults to
   `<projects_dir>/<project-name>`.
 - `projects[].default_session`: either the name of a global session template or

--- a/examples/test-config.json
+++ b/examples/test-config.json
@@ -37,6 +37,13 @@
             ]
         }
     },
+    "machines": [
+        {
+            "name": "pi",
+            "address": "100.96.91.58",
+            "username": "piquel"
+        }
+    ],
     "projects": [
         {
             "repository": "git@github.com:PiquelChips/piquel-cli.git",

--- a/flake.nix
+++ b/flake.nix
@@ -68,8 +68,8 @@
                                             machines = [
                                                 {
                                                     name = "pi";
-                                                    address = "pi.local";
-                                                    username = "ronan";
+                                                    address = "100.96.91.58";
+                                                    username = "piquel";
                                                 }
                                             ];
                                             projects = [

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,13 @@
                                             sessions.default.windows = [
                                                 { commands = [ "echo ready" ]; }
                                             ];
+                                            machines = [
+                                                {
+                                                    name = "pi";
+                                                    address = "pi.local";
+                                                    username = "ronan";
+                                                }
+                                            ];
                                             projects = [
                                                 {
                                                     repository = "https://github.com/PiquelChips/piquel-cli.git";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -21,6 +21,7 @@ let
               lib.makeBinPath [
                 pkgs.fzf
                 pkgs.git
+                pkgs.openssh
                 pkgs.tmux
               ]
             }
@@ -100,6 +101,23 @@ in
                 };
               };
             };
+
+            machineConfigType = types.submodule {
+              options = {
+                name = mkOption {
+                  type = types.str;
+                  description = "Machine name used by piquel's -m/--machine flag.";
+                };
+                address = mkOption {
+                  type = types.str;
+                  description = "SSH server address for the machine.";
+                };
+                username = mkOption {
+                  type = types.str;
+                  description = "SSH username for the machine.";
+                };
+              };
+            };
           in
           {
             projects_dir = mkOption {
@@ -130,6 +148,12 @@ in
               type = types.listOf projectConfigType;
               default = [ ];
               description = "Configured projects.";
+            };
+
+            machines = mkOption {
+              type = types.listOf machineConfigType;
+              default = [ ];
+              description = "Configured SSH machines.";
             };
           };
       };

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -10,6 +10,9 @@ use thiserror::Error;
 mod local;
 pub use local::LocalBackend;
 
+mod ssh;
+pub use ssh::SshBackend;
+
 /// Standard input configuration for an executed command.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum CommandInput {

--- a/src/backend/ssh.rs
+++ b/src/backend/ssh.rs
@@ -31,7 +31,7 @@ impl SshBackend {
         let remote_command = parts.join(" ");
 
         CommandRequest::new("ssh")
-            .args(["-t", &self.target, &remote_command])
+            .args(["-t", "--", &self.target, &remote_command])
             .stdin(stdin)
     }
 

--- a/src/backend/ssh.rs
+++ b/src/backend/ssh.rs
@@ -8,6 +8,12 @@ use crate::MachineConfig;
 
 use super::{Backend, BackendError, CommandInput, CommandOutput, CommandRequest, LocalBackend};
 
+const PREDICATE_FALSE_EXIT_CODE: i32 = 1;
+const COMMAND_NOT_FOUND_EXIT_CODE: i32 = 127;
+const TEST_FALSE_EXIT_CODES: &[i32] = &[PREDICATE_FALSE_EXIT_CODE];
+const PROGRAM_MISSING_EXIT_CODES: &[i32] =
+    &[PREDICATE_FALSE_EXIT_CODE, COMMAND_NOT_FOUND_EXIT_CODE];
+
 /// SSH process-backed backend for a configured remote machine.
 #[derive(Debug, Clone)]
 pub struct SshBackend {
@@ -51,9 +57,13 @@ impl SshBackend {
             .output(self.ssh_request(request, CommandInput::Closed, false))
     }
 
-    fn bool_status(&self, request: &CommandRequest) -> Result<bool, BackendError> {
+    fn bool_status(
+        &self,
+        request: &CommandRequest,
+        expected_false_codes: &[i32],
+    ) -> Result<bool, BackendError> {
         let status = self.shell_status(request)?;
-        Ok(status.success())
+        success_or_expected_false(status, expected_false_codes)
     }
 }
 
@@ -82,17 +92,17 @@ impl Backend for SshBackend {
     }
 
     fn path_exists(&self, path: &Path) -> Result<bool, BackendError> {
-        self.bool_status(&shell_request(&format!(
-            "test -e {}",
-            shell_quote_path(path)
-        )))
+        self.bool_status(
+            &shell_request(&format!("test -e {}", shell_quote_path(path))),
+            TEST_FALSE_EXIT_CODES,
+        )
     }
 
     fn path_is_dir(&self, path: &Path) -> Result<bool, BackendError> {
-        self.bool_status(&shell_request(&format!(
-            "test -d {}",
-            shell_quote_path(path)
-        )))
+        self.bool_status(
+            &shell_request(&format!("test -d {}", shell_quote_path(path))),
+            TEST_FALSE_EXIT_CODES,
+        )
     }
 
     fn create_dir_all(&self, path: &Path) -> Result<(), BackendError> {
@@ -124,7 +134,7 @@ impl Backend for SshBackend {
             format!("command -v {} >/dev/null 2>&1", shell_quote_os(program))
         };
 
-        if self.bool_status(&shell_request(&command))? {
+        if self.bool_status(&shell_request(&command), PROGRAM_MISSING_EXIT_CODES)? {
             Ok(())
         } else {
             Err(BackendError::MissingProgram(
@@ -153,6 +163,26 @@ fn successful_output_path(output: &CommandOutput) -> Result<PathBuf, BackendErro
     ))
 }
 
+fn success_or_expected_false(
+    status: ExitStatus,
+    expected_false_codes: &[i32],
+) -> Result<bool, BackendError> {
+    if status.success() {
+        return Ok(true);
+    }
+
+    if status
+        .code()
+        .is_some_and(|code| expected_false_codes.contains(&code))
+    {
+        return Ok(false);
+    }
+
+    Err(BackendError::Io(std::io::Error::other(format!(
+        "ssh predicate exited with status {status}"
+    ))))
+}
+
 fn program_is_path(program: &OsStr) -> bool {
     let path = Path::new(program);
     path.is_absolute() || path.components().count() > 1
@@ -168,4 +198,50 @@ fn shell_quote_os(value: &OsStr) -> String {
 
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SUCCESS_EXIT_CODE: i32 = 0;
+    const SSH_CONNECTION_FAILURE_EXIT_CODE: i32 = 255;
+
+    #[test]
+    fn predicate_statuses_accept_success_and_expected_false_codes() {
+        assert!(
+            success_or_expected_false(status(SUCCESS_EXIT_CODE), TEST_FALSE_EXIT_CODES)
+                .expect("success should be accepted")
+        );
+        assert!(
+            !success_or_expected_false(status(PREDICATE_FALSE_EXIT_CODE), TEST_FALSE_EXIT_CODES)
+                .expect("expected false should be accepted")
+        );
+        assert!(
+            !success_or_expected_false(
+                status(COMMAND_NOT_FOUND_EXIT_CODE),
+                PROGRAM_MISSING_EXIT_CODES
+            )
+            .expect("expected false should be accepted")
+        );
+    }
+
+    #[test]
+    fn predicate_statuses_reject_unexpected_failures() {
+        let err = success_or_expected_false(
+            status(SSH_CONNECTION_FAILURE_EXIT_CODE),
+            TEST_FALSE_EXIT_CODES,
+        )
+        .expect_err("ssh transport failures should be errors");
+
+        assert!(matches!(err, BackendError::Io(_)));
+        assert!(err.to_string().contains("ssh predicate exited"));
+    }
+
+    #[cfg(unix)]
+    fn status(code: i32) -> ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+
+        ExitStatus::from_raw(code << 8)
+    }
 }

--- a/src/backend/ssh.rs
+++ b/src/backend/ssh.rs
@@ -25,24 +25,30 @@ impl SshBackend {
         }
     }
 
-    fn ssh_request(&self, request: &CommandRequest, stdin: CommandInput) -> CommandRequest {
+    fn ssh_request(
+        &self,
+        request: &CommandRequest,
+        stdin: CommandInput,
+        allocate_tty: bool,
+    ) -> CommandRequest {
         let mut parts = vec![shell_quote_os(request.program())];
         parts.extend(request.args_os().map(shell_quote_os));
         let remote_command = parts.join(" ");
+        let tty_flag = if allocate_tty { "-t" } else { "-T" };
 
         CommandRequest::new("ssh")
-            .args(["-t", "--", &self.target, &remote_command])
+            .args([tty_flag, "--", &self.target, &remote_command])
             .stdin(stdin)
     }
 
     fn shell_status(&self, request: &CommandRequest) -> Result<ExitStatus, BackendError> {
         self.local
-            .status(self.ssh_request(request, CommandInput::Closed))
+            .status(self.ssh_request(request, CommandInput::Closed, false))
     }
 
     fn shell_output(&self, request: &CommandRequest) -> Result<CommandOutput, BackendError> {
         self.local
-            .output(self.ssh_request(request, CommandInput::Closed))
+            .output(self.ssh_request(request, CommandInput::Closed, false))
     }
 
     fn bool_status(&self, request: &CommandRequest) -> Result<bool, BackendError> {
@@ -55,13 +61,14 @@ impl Backend for SshBackend {
     fn output(&self, request: CommandRequest) -> Result<CommandOutput, BackendError> {
         self.validate_program(request.program())?;
         self.local
-            .output(self.ssh_request(&request, request.stdin_config().clone()))
+            .output(self.ssh_request(&request, request.stdin_config().clone(), false))
     }
 
     fn status(&self, request: CommandRequest) -> Result<ExitStatus, BackendError> {
         self.validate_program(request.program())?;
+        let allocate_tty = matches!(request.stdin_config(), CommandInput::Inherit);
         self.local
-            .status(self.ssh_request(&request, request.stdin_config().clone()))
+            .status(self.ssh_request(&request, request.stdin_config().clone(), allocate_tty))
     }
 
     fn home_dir(&self) -> Result<PathBuf, BackendError> {

--- a/src/backend/ssh.rs
+++ b/src/backend/ssh.rs
@@ -1,0 +1,164 @@
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::ExitStatus,
+};
+
+use crate::MachineConfig;
+
+use super::{Backend, BackendError, CommandInput, CommandOutput, CommandRequest, LocalBackend};
+
+/// SSH process-backed backend for a configured remote machine.
+#[derive(Debug, Clone)]
+pub struct SshBackend {
+    local: LocalBackend,
+    target: String,
+}
+
+impl SshBackend {
+    /// Creates an SSH backend for `machine`.
+    #[must_use]
+    pub fn new(machine: &MachineConfig) -> Self {
+        Self {
+            target: format!("{}@{}", machine.username(), machine.address()),
+            local: LocalBackend,
+        }
+    }
+
+    fn ssh_request(&self, request: &CommandRequest, stdin: CommandInput) -> CommandRequest {
+        let mut parts = vec![shell_quote_os(request.program())];
+        parts.extend(request.args_os().map(shell_quote_os));
+        let remote_command = parts.join(" ");
+
+        CommandRequest::new("ssh")
+            .args(["-t", &self.target, &remote_command])
+            .stdin(stdin)
+    }
+
+    fn shell_status(&self, request: &CommandRequest) -> Result<ExitStatus, BackendError> {
+        self.local
+            .status(self.ssh_request(request, CommandInput::Closed))
+    }
+
+    fn shell_output(&self, request: &CommandRequest) -> Result<CommandOutput, BackendError> {
+        self.local
+            .output(self.ssh_request(request, CommandInput::Closed))
+    }
+
+    fn bool_status(&self, request: &CommandRequest) -> Result<bool, BackendError> {
+        let status = self.shell_status(request)?;
+        Ok(status.success())
+    }
+}
+
+impl Backend for SshBackend {
+    fn output(&self, request: CommandRequest) -> Result<CommandOutput, BackendError> {
+        self.validate_program(request.program())?;
+        self.local
+            .output(self.ssh_request(&request, request.stdin_config().clone()))
+    }
+
+    fn status(&self, request: CommandRequest) -> Result<ExitStatus, BackendError> {
+        self.validate_program(request.program())?;
+        self.local
+            .status(self.ssh_request(&request, request.stdin_config().clone()))
+    }
+
+    fn home_dir(&self) -> Result<PathBuf, BackendError> {
+        let output = self.shell_output(&shell_request("printf '%s\\n' \"$HOME\""))?;
+        successful_output_path(&output)
+    }
+
+    fn current_dir(&self) -> Result<PathBuf, BackendError> {
+        let output = self.shell_output(&shell_request("pwd -P"))?;
+        successful_output_path(&output)
+    }
+
+    fn path_exists(&self, path: &Path) -> Result<bool, BackendError> {
+        self.bool_status(&shell_request(&format!(
+            "test -e {}",
+            shell_quote_path(path)
+        )))
+    }
+
+    fn path_is_dir(&self, path: &Path) -> Result<bool, BackendError> {
+        self.bool_status(&shell_request(&format!(
+            "test -d {}",
+            shell_quote_path(path)
+        )))
+    }
+
+    fn create_dir_all(&self, path: &Path) -> Result<(), BackendError> {
+        let status = self.shell_status(&shell_request(&format!(
+            "mkdir -p {}",
+            shell_quote_path(path)
+        )))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(BackendError::Io(std::io::Error::other(format!(
+                "ssh mkdir exited with status {status}"
+            ))))
+        }
+    }
+
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, BackendError> {
+        let output = self.shell_output(&shell_request(&format!(
+            "cd -P {} && pwd -P",
+            shell_quote_path(path)
+        )))?;
+        successful_output_path(&output)
+    }
+
+    fn validate_program(&self, program: &OsStr) -> Result<(), BackendError> {
+        let command = if program_is_path(program) {
+            format!("test -x {}", shell_quote_os(program))
+        } else {
+            format!("command -v {} >/dev/null 2>&1", shell_quote_os(program))
+        };
+
+        if self.bool_status(&shell_request(&command))? {
+            Ok(())
+        } else {
+            Err(BackendError::MissingProgram(
+                program.to_string_lossy().into_owned(),
+            ))
+        }
+    }
+}
+
+fn shell_request(command: &str) -> CommandRequest {
+    CommandRequest::new("sh").args(["-lc", command])
+}
+
+fn successful_output_path(output: &CommandOutput) -> Result<PathBuf, BackendError> {
+    if !output.status.success() {
+        return Err(BackendError::Io(std::io::Error::other(format!(
+            "ssh command exited with status {}",
+            output.status
+        ))));
+    }
+
+    Ok(PathBuf::from(
+        String::from_utf8_lossy(&output.stdout)
+            .trim_end()
+            .to_owned(),
+    ))
+}
+
+fn program_is_path(program: &OsStr) -> bool {
+    let path = Path::new(program);
+    path.is_absolute() || path.components().count() > 1
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    shell_quote_os(path.as_os_str())
+}
+
+fn shell_quote_os(value: &OsStr) -> String {
+    shell_quote(&value.to_string_lossy())
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 
 use crate::{
     Config,
-    backend::{Backend, LocalBackend},
+    backend::{Backend, LocalBackend, SshBackend},
     config, tmux,
 };
 
@@ -22,6 +22,10 @@ pub struct Cli {
     /// custom path to configuration
     #[arg(long = "config", value_name = "path", global = true)]
     config_path: Option<PathBuf>,
+
+    /// configured machine to run commands on over SSH
+    #[arg(short = 'm', long = "machine", value_name = "name", global = true)]
+    machine: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
@@ -125,14 +129,14 @@ impl State {
 /// cannot be loaded, or the selected command fails.
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
-    let backend: Box<dyn Backend> = Box::<LocalBackend>::default();
+    let local_backend = LocalBackend;
 
     let config_path = cli
         .config_path
         .or_else(|| std::env::var_os(CONFIG_ENV_VAR).map(PathBuf::from))
         .map_or_else(
             || {
-                backend
+                local_backend
                     .home_dir()
                     .context("home directory not found")
                     .map(|home| home.join(".config/piquel/config.json"))
@@ -140,7 +144,17 @@ pub fn run() -> Result<()> {
             Ok,
         )?;
 
-    let config = config::load_config(&config_path, backend.as_ref())?;
+    let mut config = config::read_config(&config_path)?;
+    let backend: Box<dyn Backend> = match cli.machine.as_deref() {
+        Some(machine_name) => {
+            let machine = config
+                .machine(machine_name)
+                .ok_or_else(|| anyhow::anyhow!("Machine \"{machine_name}\" is not configured"))?;
+            Box::new(SshBackend::new(machine))
+        }
+        None => Box::new(local_backend),
+    };
+    config.validate_and_normalize(backend.as_ref())?;
     let state = State::with_backend(config, backend);
 
     match &cli.command {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,13 +145,41 @@ pub fn run() -> Result<()> {
         )?;
 
     let mut config = config::read_config(&config_path)?;
-    let backend: Box<dyn Backend> = match cli.machine.as_deref() {
-        Some(machine_name) => {
-            let machine = config
+    let selected_machine = cli
+        .machine
+        .as_deref()
+        .map(|machine_name| {
+            config
                 .machine(machine_name)
-                .ok_or_else(|| anyhow::anyhow!("Machine \"{machine_name}\" is not configured"))?;
-            Box::new(SshBackend::new(machine))
+                .ok_or_else(|| anyhow::anyhow!("Machine \"{machine_name}\" is not configured"))
+        })
+        .transpose()?;
+
+    if matches!(
+        cli.command,
+        Commands::Project {
+            command: ProjectCommands::List
         }
+    ) {
+        config.validate_and_normalize(&local_backend)?;
+
+        let mut projects = config
+            .projects
+            .iter()
+            .filter_map(|project| project.resolved_name().ok())
+            .collect::<Vec<_>>();
+
+        projects.sort();
+        projects.dedup();
+
+        for project in projects {
+            println!("{project}");
+        }
+        return Ok(());
+    }
+
+    let backend: Box<dyn Backend> = match selected_machine {
+        Some(machine) => Box::new(SshBackend::new(machine)),
         None => Box::new(local_backend),
     };
     config.validate_and_normalize(backend.as_ref())?;
@@ -161,7 +189,7 @@ pub fn run() -> Result<()> {
         Commands::List => state.list(),
         Commands::Pick { project, session } => state.pick(project.as_deref(), session.as_deref()),
         Commands::Project { command } => match command {
-            ProjectCommands::List => state.list_projects(),
+            ProjectCommands::List => Ok(()), // should have been run before state creation
             ProjectCommands::Load {
                 project,
                 session,

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -5,30 +5,6 @@ use anyhow::{Context, Result, anyhow, bail};
 use crate::{ResolvedProject, SessionConfig, cli::State, git, tmux};
 
 impl State {
-    /// Lists configured projects.
-    ///
-    /// # Errors
-    ///
-    /// This currently does not fail, but returns `Result` to match CLI command
-    /// handler dispatch.
-    pub fn list_projects(&self) -> Result<()> {
-        let mut projects = self
-            .config
-            .projects
-            .iter()
-            .filter_map(|project| project.resolved_name().ok())
-            .collect::<Vec<_>>();
-
-        projects.sort();
-        projects.dedup();
-
-        for project in projects {
-            println!("{project}");
-        }
-
-        Ok(())
-    }
-
     /// Loads a configured project, optionally opening a branch worktree.
     ///
     /// # Errors

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,10 +27,19 @@ pub enum ConfigError {
 /// Returns an error if the file cannot be read, the JSON cannot be parsed, or
 /// validation fails.
 pub fn load_config(config_path: &Path, backend: &dyn Backend) -> Result<Config, ConfigError> {
+    let mut parsed = read_config(config_path)?;
+    parsed.validate_and_normalize(backend)?;
+    Ok(parsed)
+}
+
+/// Reads the JSON config from `config_path` without normalizing backend paths.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read or the JSON cannot be parsed.
+pub fn read_config(config_path: &Path) -> Result<Config, ConfigError> {
     let config_file = std::fs::read_to_string(config_path)
         .map_err(|_| ConfigError::FileNotFound(config_path.to_owned()))?;
 
-    let mut parsed: Config = serde_json::from_str(&config_file).map_err(ConfigError::ParseError)?;
-    parsed.validate_and_normalize(backend)?;
-    Ok(parsed)
+    serde_json::from_str(&config_file).map_err(ConfigError::ParseError)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,42 @@ pub enum ProjectSessionConfig {
     Inline(SessionConfig),
 }
 
+/// Configuration for a machine reachable over SSH.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MachineConfig {
+    name: String,
+    address: String,
+    username: String,
+}
+
+impl MachineConfig {
+    fn validate(&self) -> Result<(), ConfigError> {
+        validate_machine_field(&self.name, "name")?;
+        validate_machine_field(&self.address, "address")?;
+        validate_machine_field(&self.username, "username")?;
+        Ok(())
+    }
+
+    /// Returns the machine name used by the `--machine` flag.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the SSH server address.
+    #[must_use]
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    /// Returns the SSH username.
+    #[must_use]
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+}
+
 /// Complete JSON configuration for the CLI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -151,6 +187,8 @@ pub struct Config {
     sessions: HashMap<String, SessionConfig>,
     #[serde(default)]
     projects: Vec<ProjectConfig>,
+    #[serde(default)]
+    machines: Vec<MachineConfig>,
 }
 
 impl Config {
@@ -161,6 +199,17 @@ impl Config {
     /// Returns an error if session templates, project names, project paths, or
     /// default-session references are invalid.
     pub fn validate_and_normalize(&mut self, backend: &dyn Backend) -> Result<(), ConfigError> {
+        let mut machine_names = HashSet::new();
+        for machine in &self.machines {
+            machine.validate()?;
+            if !machine_names.insert(machine.name.clone()) {
+                return Err(ConfigError::Validation(format!(
+                    "Duplicate machine name \"{}\"",
+                    machine.name
+                )));
+            }
+        }
+
         self.projects_dir = backend.expand_home(&self.projects_dir)?;
         self.worktrees_dir = backend.expand_home(&self.worktrees_dir)?;
 
@@ -220,6 +269,12 @@ impl Config {
     #[must_use]
     pub fn session_template(&self, name: &str) -> Option<&SessionConfig> {
         self.sessions.get(name)
+    }
+
+    /// Returns the configured machine by name.
+    #[must_use]
+    pub fn machine(&self, name: &str) -> Option<&MachineConfig> {
+        self.machines.iter().find(|machine| machine.name == name)
     }
 
     /// Returns a normalized project by name.
@@ -310,6 +365,16 @@ fn validate_project_name(name: &str) -> Result<(), ConfigError> {
     Ok(())
 }
 
+fn validate_machine_field(value: &str, field: &str) -> Result<(), ConfigError> {
+    if value.trim().is_empty() {
+        return Err(ConfigError::Validation(format!(
+            "Machine {field} must not be empty"
+        )));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,6 +400,7 @@ mod tests {
             default_session: "default".to_owned(),
             sessions: HashMap::from([("default".to_owned(), session())]),
             projects: vec![],
+            machines: vec![],
         }
     }
 
@@ -457,6 +523,7 @@ mod tests {
             default_session: "missing".to_owned(),
             sessions: HashMap::from([("default".to_owned(), session())]),
             projects: vec![],
+            machines: vec![],
         };
 
         assert!(config.validate_and_normalize(&backend()).is_err());
@@ -471,6 +538,7 @@ mod tests {
                 default_session: name.to_owned(),
                 sessions: HashMap::from([(name.to_owned(), session())]),
                 projects: vec![],
+                machines: vec![],
             };
 
             assert!(
@@ -488,6 +556,7 @@ mod tests {
             default_session: "default".to_owned(),
             sessions: HashMap::from([("default".to_owned(), SessionConfig { windows: vec![] })]),
             projects: vec![],
+            machines: vec![],
         };
 
         assert!(config.validate_and_normalize(&backend()).is_err());

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -85,7 +85,7 @@ pub fn parse_list_sessions_output(output: &CommandOutput) -> Result<Vec<String>,
 /// Returns the command request for attaching to a tmux session.
 #[must_use]
 pub fn attach_request(session: &str) -> CommandRequest {
-    tmux_request(["attach", "-t", session])
+    tmux_request(["attach", "-t", session]).stdin(CommandInput::Inherit)
 }
 
 /// Attaches to an existing tmux session through `backend`.
@@ -93,9 +93,9 @@ pub fn attach_request(session: &str) -> CommandRequest {
 /// # Errors
 ///
 /// Returns an error if tmux cannot attach to the requested session.
-pub fn attach(backend: &dyn Backend, name: &str) -> Result<String, TmuxError> {
-    let output = backend.output(attach_request(name))?;
-    successful_output(&output)
+pub fn attach(backend: &dyn Backend, name: &str) -> Result<(), TmuxError> {
+    let status = backend.status(attach_request(name))?;
+    successful_status(status)
 }
 
 /// Returns the command request for creating a detached tmux session.
@@ -345,9 +345,7 @@ pub fn validated_session_name(input: &str) -> Result<String, TmuxError> {
 }
 
 fn tmux_request<'a>(args: impl IntoIterator<Item = &'a str>) -> CommandRequest {
-    CommandRequest::new("tmux")
-        .args(args)
-        .stdin(CommandInput::Inherit)
+    CommandRequest::new("tmux").args(args)
 }
 
 fn create_window(
@@ -431,7 +429,7 @@ mod tests {
         );
         assert_eq!(
             attach_request("alpha"),
-            tmux_request(["attach", "-t", "alpha"])
+            tmux_request(["attach", "-t", "alpha"]).stdin(CommandInput::Inherit)
         );
         assert_eq!(
             new_session_request("alpha", Path::new("/repo")),
@@ -552,11 +550,8 @@ mod tests {
         open_session(&backend, "alpha", Path::new("/repo"), &template)
             .expect("existing session should attach");
 
-        assert_eq!(
-            backend.output_requests(),
-            vec![list_sessions_request(), attach_request("alpha")]
-        );
-        assert!(backend.status_requests().is_empty());
+        assert_eq!(backend.output_requests(), vec![list_sessions_request()]);
+        assert_eq!(backend.status_requests(), vec![attach_request("alpha")]);
     }
 
     #[test]
@@ -595,7 +590,6 @@ mod tests {
                 send_keys_request("@1", "vim ."),
                 new_window_request("feature_foo", Path::new("/repo"), &template.windows[1]),
                 send_keys_request("@2", "cargo test"),
-                attach_request("feature_foo"),
             ]
         );
         assert_eq!(
@@ -604,6 +598,7 @@ mod tests {
                 new_session_request("feature_foo", Path::new("/repo")),
                 kill_window_request("@0"),
                 select_window_request("@1"),
+                attach_request("feature_foo"),
             ]
         );
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -164,6 +164,60 @@ exit 64
     )
 }
 
+fn fake_ssh_script(log: &Path, list_sessions: &str) -> String {
+    format!(
+        r#"#!{}
+log={}
+target=$2
+cmd=$3
+printf '%s	%s\n' "$target" "$cmd" >> "$log"
+
+case "$cmd" in
+    *"printf "*"HOME"*)
+        printf '/home/pi\n'
+        exit 0
+        ;;
+    *"pwd -P"*)
+        printf '/home/pi\n'
+        exit 0
+        ;;
+    *"command -v "*)
+        exit 0
+        ;;
+    *"test -e "*|*"test -d "*|*"mkdir -p "*)
+        exit 0
+        ;;
+esac
+
+case "$cmd" in
+    *"'tmux' 'list-sessions'"*)
+        printf '{}'
+        exit 0
+        ;;
+    *"'tmux' 'new-session'"*)
+        exit 0
+        ;;
+    *"'tmux' 'list-windows'"*)
+        printf 'bootstrap-window\n'
+        exit 0
+        ;;
+    *"'tmux' 'new-window'"*)
+        printf 'window-id\n'
+        exit 0
+        ;;
+    *"'tmux' 'send-keys'"*|*"'tmux' 'kill-window'"*|*"'tmux' 'select-window'"*|*"'tmux' 'attach'"*)
+        exit 0
+        ;;
+esac
+
+exit 64
+"#,
+        path_str(&shell_path()),
+        shell_quote(path_str(log)),
+        list_sessions
+    )
+}
+
 fn fake_fzf_script(selection: &str, input_log: &Path) -> String {
     format!(
         r"#!{}
@@ -683,6 +737,118 @@ exit 64
         .expect("piquel should run");
 
     assert_success(&output, "alpha\nzeta\n", "");
+}
+
+#[test]
+fn list_with_machine_runs_tmux_over_ssh() {
+    let temp = TestDir::new();
+    let config = write_config(
+        &temp,
+        r#"{
+            "default_session": "default",
+            "sessions": {
+                "default": { "windows": [{ "commands": [] }] }
+            },
+            "machines": [
+                {
+                    "name": "pi",
+                    "address": "pi.example.test",
+                    "username": "ronan"
+                }
+            ]
+        }"#,
+    );
+    let ssh_log = temp.path().join("ssh.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[("ssh", fake_ssh_script(&ssh_log, "zeta\nalpha\nzeta\n"))],
+    );
+
+    let output = piquel()
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "--machine", "pi", "list"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "alpha\nzeta\n", "");
+
+    let log = fs::read_to_string(ssh_log).expect("ssh log should be readable");
+    assert!(log.contains("ronan@pi.example.test"));
+    assert!(log.contains("'tmux' 'list-sessions' '-F' '#{session_name}'"));
+}
+
+#[test]
+fn unknown_machine_exits_before_running_ssh() {
+    let temp = TestDir::new();
+    let config = config_with_projects(&temp);
+    let ssh_log = temp.path().join("ssh.log");
+    let bin = bin_dir_with(&temp, &[("ssh", fake_ssh_script(&ssh_log, ""))]);
+
+    let output = piquel()
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "--machine", "pi", "list"])
+        .output()
+        .expect("piquel should run");
+
+    assert_failure(&output, &["Machine \"pi\" is not configured"]);
+    assert!(!ssh_log.exists(), "ssh should not be invoked");
+}
+
+#[test]
+fn project_load_with_machine_opens_remote_tmux_session() {
+    let temp = TestDir::new();
+    let config = write_config(
+        &temp,
+        r#"{
+            "default_session": "default",
+            "sessions": {
+                "default": {
+                    "windows": [
+                        { "name": "editor", "commands": ["vim ."] }
+                    ]
+                }
+            },
+            "projects": [
+                {
+                    "repository": "https://github.com/owner/alpha.git",
+                    "path": "/srv/projects/alpha"
+                }
+            ],
+            "machines": [
+                {
+                    "name": "pi",
+                    "address": "pi.local",
+                    "username": "ronan"
+                }
+            ]
+        }"#,
+    );
+    let ssh_log = temp.path().join("ssh.log");
+    let bin = bin_dir_with(&temp, &[("ssh", fake_ssh_script(&ssh_log, ""))]);
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args([
+            "--config",
+            path_str(&config),
+            "-m",
+            "pi",
+            "project",
+            "load",
+            "alpha",
+        ])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+
+    let log = fs::read_to_string(ssh_log).expect("ssh log should be readable");
+    assert!(log.contains("ronan@pi.local"));
+    assert!(log.contains("'tmux' 'new-session' '-d' '-c' '/srv/projects/alpha' '-s' 'alpha'"));
+    assert!(log.contains("'tmux' 'new-window' '-P' '-F' '#{window_id}' '-n' 'editor' '-t' 'alpha' '-c' '/srv/projects/alpha'"));
+    assert!(log.contains("'tmux' 'send-keys' '-t' 'window-id' 'vim .' 'Enter'"));
+    assert!(log.contains("'tmux' 'attach' '-t' 'alpha'"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -75,10 +75,9 @@ fn path_str(path: &Path) -> &str {
 }
 
 fn shell_path() -> PathBuf {
-    if let Some(shell) = std::env::var_os("SHELL").map(PathBuf::from)
-        && shell.exists()
-    {
-        return shell;
+    let system_sh = PathBuf::from("/bin/sh");
+    if system_sh.exists() {
+        return system_sh;
     }
 
     std::env::var_os("PATH")
@@ -164,12 +163,68 @@ exit 64
     )
 }
 
+fn fake_tmux_argv_script(log: &Path) -> String {
+    format!(
+        r#"#!{}
+log={}
+printf 'argc=%s\n' "$#" >> "$log"
+for arg in "$@"; do
+    printf '[%s]\n' "$arg" >> "$log"
+done
+
+case "$1" in
+    list-sessions)
+        exit 0
+        ;;
+    new-session)
+        exit 0
+        ;;
+    list-windows)
+        printf 'bootstrap-window\n'
+        exit 0
+        ;;
+    new-window)
+        printf 'window-id\n'
+        exit 0
+        ;;
+    send-keys|kill-window|select-window|attach)
+        exit 0
+        ;;
+esac
+
+exit 64
+"#,
+        path_str(&shell_path()),
+        shell_quote(path_str(log))
+    )
+}
+
+fn machine_config(address: &str) -> String {
+    format!(
+        r#""machines": [
+                {{
+                    "name": "pi",
+                    "address": {},
+                    "username": "ronan"
+                }}
+            ],"#,
+        serde_json::to_string(address).expect("address should serialize")
+    )
+}
+
 fn fake_ssh_script(log: &Path, list_sessions: &str) -> String {
     format!(
         r#"#!{}
 log={}
-target=$2
-cmd=$3
+remote_bin=$(dirname "$0")
+PATH="$remote_bin:$PATH"
+export PATH
+shift
+if [ "$1" = "--" ]; then
+    shift
+fi
+target=$1
+cmd=$2
 printf '%s	%s\n' "$target" "$cmd" >> "$log"
 
 case "$cmd" in
@@ -215,6 +270,42 @@ exit 64
         path_str(&shell_path()),
         shell_quote(path_str(log)),
         list_sessions
+    )
+}
+
+fn fake_ssh_eval_script(log: &Path) -> String {
+    format!(
+        r#"#!{}
+log={}
+remote_bin=$(dirname "$0")
+PATH="$remote_bin:$PATH"
+export PATH
+shift
+if [ "$1" = "--" ]; then
+    shift
+fi
+target=$1
+cmd=$2
+printf 'target=%s\ncmd=%s\n' "$target" "$cmd" >> "$log"
+sh -c "$cmd"
+"#,
+        path_str(&shell_path()),
+        shell_quote(path_str(log))
+    )
+}
+
+fn fake_remote_sh_script() -> String {
+    format!(
+        r#"#!{}
+if [ "$1" = "-lc" ]; then
+    shift
+    exec {} -c "$@"
+fi
+exec {} "$@"
+"#,
+        path_str(&shell_path()),
+        shell_quote(path_str(&shell_path())),
+        shell_quote(path_str(&shell_path()))
     )
 }
 
@@ -740,6 +831,44 @@ exit 64
 }
 
 #[test]
+fn list_without_machine_stays_local_even_when_machines_are_configured() {
+    let temp = TestDir::new();
+    let config = write_config(
+        &temp,
+        &format!(
+            r#"{{
+                "default_session": "default",
+                "sessions": {{
+                    "default": {{ "windows": [{{ "commands": [] }}] }}
+                }},
+                {}
+                "projects": []
+            }}"#,
+            machine_config("pi.example.test")
+        ),
+    );
+    let tmux_log = temp.path().join("tmux.log");
+    let ssh_log = temp.path().join("ssh.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("tmux", fake_tmux_script(&tmux_log, "zeta\nalpha\nzeta\n")),
+            ("ssh", fake_ssh_script(&ssh_log, "")),
+        ],
+    );
+
+    let output = piquel()
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "list"])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "alpha\nzeta\n", "");
+    assert!(tmux_log.exists(), "tmux should run locally");
+    assert!(!ssh_log.exists(), "ssh should not be invoked without -m");
+}
+
+#[test]
 fn list_with_machine_runs_tmux_over_ssh() {
     let temp = TestDir::new();
     let config = write_config(
@@ -775,6 +904,61 @@ fn list_with_machine_runs_tmux_over_ssh() {
     let log = fs::read_to_string(ssh_log).expect("ssh log should be readable");
     assert!(log.contains("ronan@pi.example.test"));
     assert!(log.contains("'tmux' 'list-sessions' '-F' '#{session_name}'"));
+}
+
+#[test]
+fn machine_ssh_destination_is_terminated_before_remote_command() {
+    let temp = TestDir::new();
+    let config = write_config(
+        &temp,
+        r#"{
+            "default_session": "default",
+            "sessions": {
+                "default": { "windows": [{ "commands": [] }] }
+            },
+            "machines": [
+                {
+                    "name": "pi",
+                    "address": "pi.local",
+                    "username": "-oProxyCommand=bad"
+                }
+            ]
+        }"#,
+    );
+    let ssh_log = temp.path().join("ssh.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("ssh", fake_ssh_eval_script(&ssh_log)),
+            ("sh", fake_remote_sh_script()),
+            ("tmux", fake_tmux_script(&temp.path().join("tmux.log"), "")),
+        ],
+    );
+
+    let output = piquel()
+        .env("PATH", prepend_path(&bin))
+        .args(["--config", path_str(&config), "--machine", "pi", "list"])
+        .output()
+        .expect("piquel should run");
+
+    let log = fs::read_to_string(ssh_log).expect("ssh log should be readable");
+    assert!(
+        output.status.success(),
+        "expected success, got status {}\nstdout:\n{}\nstderr:\n{}\nssh log:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        log
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "",
+        "ssh log:\n{log}"
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
+    assert!(log.contains("target=-oProxyCommand=bad@pi.local\n"));
+    assert!(log.contains("cmd='tmux' 'list-sessions' '-F' '#{session_name}'"));
 }
 
 #[test]
@@ -849,6 +1033,81 @@ fn project_load_with_machine_opens_remote_tmux_session() {
     assert!(log.contains("'tmux' 'new-window' '-P' '-F' '#{window_id}' '-n' 'editor' '-t' 'alpha' '-c' '/srv/projects/alpha'"));
     assert!(log.contains("'tmux' 'send-keys' '-t' 'window-id' 'vim .' 'Enter'"));
     assert!(log.contains("'tmux' 'attach' '-t' 'alpha'"));
+}
+
+#[test]
+fn project_load_with_machine_shell_quotes_remote_tmux_arguments() {
+    let temp = TestDir::new();
+    let project_path = temp.path().join("remote project's dir");
+    fs::create_dir_all(&project_path).expect("project path should be created");
+    let pwned = temp.path().join("shell-was-not-quoted");
+    let command = format!("printf hacked > {}; echo done", path_str(&pwned));
+    let config = write_config(
+        &temp,
+        &format!(
+            r#"{{
+                "default_session": "default",
+                "sessions": {{
+                    "default": {{
+                        "windows": [
+                            {{ "name": "editor's window", "commands": [{}] }}
+                        ]
+                    }}
+                }},
+                {}
+                "projects": [
+                    {{
+                        "repository": "https://github.com/owner/alpha.git",
+                        "path": {}
+                    }}
+                ]
+            }}"#,
+            serde_json::to_string(&command).expect("command should serialize"),
+            machine_config("pi.local"),
+            serde_json::to_string(path_str(&project_path)).expect("path should serialize")
+        ),
+    );
+    let ssh_log = temp.path().join("ssh.log");
+    let tmux_log = temp.path().join("tmux.log");
+    let bin = bin_dir_with(
+        &temp,
+        &[
+            ("ssh", fake_ssh_eval_script(&ssh_log)),
+            ("sh", fake_remote_sh_script()),
+            ("tmux", fake_tmux_argv_script(&tmux_log)),
+        ],
+    );
+
+    let output = piquel()
+        .env_remove("TMUX")
+        .env("PATH", prepend_path(&bin))
+        .args([
+            "--config",
+            path_str(&config),
+            "-m",
+            "pi",
+            "project",
+            "load",
+            "alpha",
+        ])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "", "");
+    assert!(
+        !pwned.exists(),
+        "configured tmux command should be passed as an argument, not executed by the remote shell"
+    );
+
+    let tmux_log = fs::read_to_string(tmux_log).expect("tmux log should be readable");
+    assert!(tmux_log.contains(&format!("[{}]", path_str(&project_path))));
+    assert!(tmux_log.contains("[editor's window]"));
+    assert!(tmux_log.contains(&format!("[{command}]")));
+
+    let ssh_log = fs::read_to_string(ssh_log).expect("ssh log should be readable");
+    assert!(ssh_log.contains("remote project'\\''s dir'"));
+    assert!(ssh_log.contains("'editor'\\''s window'"));
+    assert!(ssh_log.contains("'printf hacked > "));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -219,13 +219,14 @@ log={}
 remote_bin=$(dirname "$0")
 PATH="$remote_bin:$PATH"
 export PATH
+tty_flag=$1
 shift
 if [ "$1" = "--" ]; then
     shift
 fi
 target=$1
 cmd=$2
-printf '%s	%s\n' "$target" "$cmd" >> "$log"
+printf '%s	%s	%s\n' "$tty_flag" "$target" "$cmd" >> "$log"
 
 case "$cmd" in
     *"printf "*"HOME"*)
@@ -280,13 +281,14 @@ log={}
 remote_bin=$(dirname "$0")
 PATH="$remote_bin:$PATH"
 export PATH
+tty_flag=$1
 shift
 if [ "$1" = "--" ]; then
     shift
 fi
 target=$1
 cmd=$2
-printf 'target=%s\ncmd=%s\n' "$target" "$cmd" >> "$log"
+printf 'tty=%s\ntarget=%s\ncmd=%s\n' "$tty_flag" "$target" "$cmd" >> "$log"
 sh -c "$cmd"
 "#,
         path_str(&shell_path()),
@@ -903,7 +905,10 @@ fn list_with_machine_runs_tmux_over_ssh() {
 
     let log = fs::read_to_string(ssh_log).expect("ssh log should be readable");
     assert!(log.contains("ronan@pi.example.test"));
-    assert!(log.contains("'tmux' 'list-sessions' '-F' '#{session_name}'"));
+    assert!(
+        log.contains("-T\tronan@pi.example.test\t'tmux' 'list-sessions' '-F' '#{session_name}'")
+    );
+    assert!(!log.contains("-t\tronan@pi.example.test\t'tmux' 'list-sessions'"));
 }
 
 #[test]
@@ -957,6 +962,7 @@ fn machine_ssh_destination_is_terminated_before_remote_command() {
     );
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
 
+    assert!(log.contains("tty=-T\n"));
     assert!(log.contains("target=-oProxyCommand=bad@pi.local\n"));
     assert!(log.contains("cmd='tmux' 'list-sessions' '-F' '#{session_name}'"));
 }
@@ -1029,10 +1035,12 @@ fn project_load_with_machine_opens_remote_tmux_session() {
 
     let log = fs::read_to_string(ssh_log).expect("ssh log should be readable");
     assert!(log.contains("ronan@pi.local"));
-    assert!(log.contains("'tmux' 'new-session' '-d' '-c' '/srv/projects/alpha' '-s' 'alpha'"));
+    assert!(log.contains(
+        "-T\tronan@pi.local\t'tmux' 'new-session' '-d' '-c' '/srv/projects/alpha' '-s' 'alpha'"
+    ));
     assert!(log.contains("'tmux' 'new-window' '-P' '-F' '#{window_id}' '-n' 'editor' '-t' 'alpha' '-c' '/srv/projects/alpha'"));
     assert!(log.contains("'tmux' 'send-keys' '-t' 'window-id' 'vim .' 'Enter'"));
-    assert!(log.contains("'tmux' 'attach' '-t' 'alpha'"));
+    assert!(log.contains("-t\tronan@pi.local\t'tmux' 'attach' '-t' 'alpha'"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -585,6 +585,71 @@ fn config_flag_takes_precedence_over_environment() {
 }
 
 #[test]
+fn project_list_with_machine_stays_local() {
+    let temp = TestDir::new();
+    let config = write_config(
+        &temp,
+        &format!(
+            r#"{{
+                "default_session": "default",
+                "sessions": {{
+                    "default": {{ "windows": [{{ "commands": [] }}] }}
+                }},
+                {}
+                "projects": [
+                    {{
+                        "repository": "https://github.com/owner/alpha.git"
+                    }}
+                ]
+            }}"#,
+            machine_config("pi.example.test")
+        ),
+    );
+    let ssh_log = temp.path().join("ssh.log");
+    let bin = bin_dir_with(&temp, &[("ssh", fake_ssh_script(&ssh_log, ""))]);
+
+    let output = piquel()
+        .env("PATH", prepend_path(&bin))
+        .args([
+            "--config",
+            path_str(&config),
+            "--machine",
+            "pi",
+            "project",
+            "list",
+        ])
+        .output()
+        .expect("piquel should run");
+
+    assert_success(&output, "alpha\n", "");
+    assert!(!ssh_log.exists(), "project list should not invoke ssh");
+}
+
+#[test]
+fn project_list_with_unknown_machine_fails_before_running_ssh() {
+    let temp = TestDir::new();
+    let config = config_with_projects(&temp);
+    let ssh_log = temp.path().join("ssh.log");
+    let bin = bin_dir_with(&temp, &[("ssh", fake_ssh_script(&ssh_log, ""))]);
+
+    let output = piquel()
+        .env("PATH", prepend_path(&bin))
+        .args([
+            "--config",
+            path_str(&config),
+            "--machine",
+            "pi",
+            "project",
+            "list",
+        ])
+        .output()
+        .expect("piquel should run");
+
+    assert_failure(&output, &["Machine \"pi\" is not configured"]);
+    assert!(!ssh_log.exists(), "ssh should not be invoked");
+}
+
+#[test]
 fn missing_config_file_exits_with_clear_error() {
     let temp = TestDir::new();
     let config = temp.path().join("missing.json");


### PR DESCRIPTION
## Summary
- Add `machines` to configuration so remote SSH targets can be named and resolved from `-m/--machine`.
- Introduce an `SshBackend` that runs workspace checks and tmux/git-related commands through `ssh -t` on the selected machine.
- Split config loading so raw config can be read locally before backend-specific normalization and validation.
- Update the CLI, README, and test config to document and exercise remote machine usage.
- Add integration coverage for remote tmux listing, project loading, and unknown-machine failures.