### PR TITLE
feat: shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +149,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -41,11 +41,22 @@ piquel --config examples/test-config.json project list
 Commands:
 
 ```text
+piquel completions <shell>
 piquel list
 piquel pick [project] [--session <template>]
 piquel project list
 piquel project load <project> [--session <template>] [--worktree <branch>]
 piquel session [path] [--session <template>] [--name <tmux-name>]
+```
+
+`piquel completions <shell>` prints shell completions for `bash`, `fish`, or
+`zsh`. Nix installs these completions automatically. For manual installs,
+write the generated completion to the location your shell reads:
+
+```sh
+piquel completions zsh > ~/.zfunc/_piquel
+piquel completions bash > ~/.local/share/bash-completion/completions/piquel
+piquel completions fish > ~/.config/fish/completions/piquel.fish
 ```
 
 `piquel list` prints running tmux sessions. `piquel pick` combines running

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -8,14 +8,15 @@ let
   cfg = config.programs.piquelcli;
   settingsFormat = pkgs.formats.json { };
   configFile = settingsFormat.generate "piquel-cli.json" cfg.settings;
+  basePiquel = pkgs.callPackage ./pkg.nix { };
 
   wrappedPiquel =
-    pkgs.runCommand "piquelcli-wrapped"
-      {
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-      }
-      ''
-        makeWrapper ${pkgs.callPackage ./pkg.nix { }}/bin/piquel $out/bin/piquel \
+    pkgs.symlinkJoin {
+      name = "piquelcli-wrapped";
+      paths = [ basePiquel ];
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        wrapProgram $out/bin/piquel \
             --set PIQUEL_CONFIG ${configFile} \
             --prefix PATH : ${
               lib.makeBinPath [
@@ -26,6 +27,7 @@ let
               ]
             }
       '';
+    };
 
   piquelcli = wrappedPiquel;
 in

--- a/nix/pkg.nix
+++ b/nix/pkg.nix
@@ -7,4 +7,12 @@ pkgs.rustPlatform.buildRustPackage {
   version = manifest.version;
   src = pkgs.lib.cleanSource ../.;
   cargoLock.lockFile = ../Cargo.lock;
+  nativeBuildInputs = [ pkgs.installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd piquel \
+      --bash <($out/bin/piquel completions bash) \
+      --fish <($out/bin/piquel completions fish) \
+      --zsh <($out/bin/piquel completions zsh)
+  '';
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -26,6 +27,11 @@ pub struct Cli {
 /// Top-level CLI commands.
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for.
+        shell: Shell,
+    },
     /// List running tmux sessions
     List,
     /// Interactively pick a running tmux session or configured project
@@ -113,6 +119,12 @@ impl State {
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
 
+    if let Commands::Completions { shell } = &cli.command {
+        let mut command = Cli::command();
+        generate(*shell, &mut command, "piquel", &mut std::io::stdout());
+        return Ok(());
+    }
+
     let config_path = cli
         .config_path
         .or_else(|| std::env::var_os(CONFIG_ENV_VAR).map(PathBuf::from))
@@ -152,6 +164,7 @@ pub fn run() -> Result<()> {
     let state = State::new(config);
 
     match &cli.command {
+        Commands::Completions { .. } => Ok(()), // handled before config loading
         Commands::List => state.list(),
         Commands::Pick { project, session } => state.pick(project.as_deref(), session.as_deref()),
         Commands::Project { command } => match command {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -395,6 +395,24 @@ fn config_for_session_commands(temp: &TestDir, commands: &[&str]) -> PathBuf {
 }
 
 #[test]
+fn completions_print_without_config() {
+    let output = run(["completions", "bash"]);
+
+    assert!(
+        output.status.success(),
+        "expected success, got status {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("piquel"));
+    assert!(stdout.contains("project"));
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+}
+
+#[test]
 fn project_list_prints_sorted_configured_projects() {
     let temp = TestDir::new();
     let config = config_with_projects(&temp);


### PR DESCRIPTION
Adds shell completion generation so users and packagers can install terminal completions for piquel.

The CLI now exposes `piquel completions <shell>` through `clap_complete`, and the Nix package installs generated bash, fish, and zsh completions during packaging. The NixOS module wrapper now preserves packaged completion files while still setting `PIQUEL_CONFIG` and runtime PATH entries.

Validated with:

- `nix develop -c cargo fmt --check`
- `nix develop -c cargo test --all-targets --all-features`
- `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop -c cargo deny check`
- `nix flake check`
- inspected `result/share/*` completion outputs

Changes made by GPT-5 Codex in the T3 Code harness.